### PR TITLE
Add `force` option to continue with warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For fast validation, keep that in a single group, as the validator initializatio
 
 ### `ignore`
 
-Type: `Array`, `String`, or `RegExp`
+Type: `Array`, `String`, or `RegExp`  
 Default: `null`
 
 Use this to specify the error message(s) to ignore. For example:
@@ -58,7 +58,7 @@ all: {
 
 ### `force`
 
-Type: `Boolean`
+Type: `Boolean`  
 Default: `false`
 
 Set `force` to `true` to report errors but not fail the `grunt` task.

--- a/README.md
+++ b/README.md
@@ -29,27 +29,39 @@ For fast validation, keep that in a single group, as the validator initializatio
 
 ## Options
 
-There's a single option, `ignore` (`Array`). Use this to specify the error messages to ignore. For example:
+### `ignore`
+
+Type: `Array`, `String`, or `RegExp`
+Default: `null`
+
+Use this to specify the error message(s) to ignore. For example:
 
 ```js
 all: {
 	options: {
-		ignore: ['The “clear” attribute on the “br” element is obsolete. Use CSS instead.']
+		ignore: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
 	},
 	src: "html4.html"
 }
 ```
 
-The ignore array also supports regular expressions. For example, to ignore AngularJS directive attributes:
+The ignore option also supports regular expressions. For example, to ignore AngularJS directive attributes:
 
 ```js
 all: {
 	options: {
-		ignore: [/attribute “ng-[a-z-]+” not allowed/]
+		ignore: /attribute “ng-[a-z-]+” not allowed/
 	},
 	src: "app.html"
 }
 ```
+
+### `force`
+
+Type: `Boolean`
+Default: `false`
+
+Set `force` to `true` to report errors but not fail the `grunt` task.
 
 [grunt]: http://gruntjs.com/
 [getting_started]: http://gruntjs.com/getting-started

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -17,13 +17,15 @@ module.exports = function(grunt) {
     var done = this.async(),
       files = grunt.file.expand(this.filesSrc),
       options = this.options({
-        files: files
-      });
+        files: files,
+        force: false
+      }),
+      force = options.force;
 
     htmllint(options, function(error, result) {
       if (error) {
         grunt.log.error(error);
-        done(false);
+        done(force);
         return;
       }
       if (!result.length) {
@@ -39,7 +41,7 @@ module.exports = function(grunt) {
           grunt.log.writeln(output);
         });
       }
-      done(false);
+      done(force);
     });
   });
 


### PR DESCRIPTION
With the `force` option set to `true`, you can be notified of
validation warnings without aborting the entire grunt process.

Closes #43.