### PR TITLE
Wrap `ignore` option if not already an Array

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -48,10 +48,11 @@ module.exports = function(config, done) {
             message.file = path.relative('.', message.url.replace(path.sep !== '\\' ? 'file:' : 'file:/', ''));
           });
           if (config.ignore) {
+            var ignore = config.ignore instanceof Array ? config.ignore : [config.ignore];
             result = result.filter(function(message) {
               // iterate over the ignore rules and test the message agains each rule.
               // A match should return false, which causes every() to return false and the message to be filtered out.
-              return config.ignore.every(function (currentValue) {
+              return ignore.every(function (currentValue) {
                 if (currentValue instanceof RegExp) {
                   return !currentValue.test(message.message);
                 } else {


### PR DESCRIPTION
This allows the user to set `ignore` as a single string or regexp.

Coincidentally, this fixes the currently broken
`grunt hamllint:ignore` task on this repo.