### PR TITLE
Add `reporter` option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
       }
     },
     nodeunit: {
-      files: 'test/**/*.js'
+      files: ['test/**/*.js', '!test/support/**/*.js']
     },
     jshint: {
       files: ['Grunfile.js', 'tasks/**/*.js', 'test/**/*.js'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
       files: ['test/**/*.js', '!test/support/**/*.js']
     },
     jshint: {
-      files: ['Grunfile.js', 'tasks/**/*.js', 'test/**/*.js'],
+      files: ['Gruntfile.js', 'lib/**/*.js', 'tasks/**/*.js', 'test/**/*.js'],
       options: {
         jshintrc: '.jshintrc'
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,18 @@ module.exports = function(grunt) {
           ignore: /XML processing instructions/
         },
         src: 'test/*.php'
+      },
+      checkstyle: {
+        options: {
+          reporter: 'checkstyle'
+        },
+        src: 'test/*.html'
+      },
+      json: {
+        options: {
+          reporter: 'json'
+        },
+        src: 'test/*.html'
       }
     },
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Set `force` to `true` to report errors but not fail the `grunt` task.
 
 ### `reporter`
 
-Type: `String`
+Type: `String`  
 Default: `null`
 
 Allows you to modify the output format. By default, this plugin will use a built-in Grunt reporter. Set the path to your own custom reporter or to one of the provided reporters: `checkstyle` or `json`.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Specify a filepath to output the results of a reporter. If `reporterOutput` is s
 Type: `Boolean`  
 Default: `false`
 
-Set `absoluteFilePathsForReporter` to `true` to use absolute file pathsin generated reports.
+Set `absoluteFilePathsForReporter` to `true` to use absolute file paths in generated reports.
 
 [grunt]: http://gruntjs.com/
 [getting_started]: http://gruntjs.com/getting-started

--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ Default: `false`
 
 Set `force` to `true` to report errors but not fail the `grunt` task.
 
+### `reporter`
+
+Type: `String`
+Default: `null`
+
+Allows you to modify the output format. By default, this plugin will use a built-in Grunt reporter. Set the path to your own custom reporter or to one of the build-in reporters: `checkstyle` or `json`.
+
+### `reporterOutput`
+
+Type: `String`  
+Default: `null`
+
+Specify a filepath to output the results of a reporter. If `reporterOutput` is specified then all output will be written to the given filepath rather than printed to `stdout`.
+
+### `absoluteFilePathsForReporter`
+
+Type: `Boolean`  
+Default: `false`
+
+Set `absoluteFilePathsForReporter` to `true` to use absolute file pathsin generated reports.
+
 [grunt]: http://gruntjs.com/
 [getting_started]: http://gruntjs.com/getting-started
 [vnujar]: https://validator.github.io/validator/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Set `force` to `true` to report errors but not fail the `grunt` task.
 Type: `String`
 Default: `null`
 
-Allows you to modify the output format. By default, this plugin will use a built-in Grunt reporter. Set the path to your own custom reporter or to one of the build-in reporters: `checkstyle` or `json`.
+Allows you to modify the output format. By default, this plugin will use a built-in Grunt reporter. Set the path to your own custom reporter or to one of the provided reporters: `checkstyle` or `json`.
 
 ### `reporterOutput`
 

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -45,6 +45,9 @@ module.exports = function(config, done) {
           result = JSON.parse(stderr).messages;
           result.forEach(function(message) {
             message.file = path.relative('.', message.url.replace(path.sep !== '\\' ? 'file:' : 'file:/', ''));
+            if (config.absoluteFilePathsForReporter) {
+              message.file = path.resolve(message.file);
+            }
           });
           if (config.ignore) {
             var ignore = config.ignore instanceof Array ? config.ignore : [config.ignore];

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var path = require('path');
+var chalk = require('chalk');
+
+// Default Grunt reporter
+var defaultReporter = function (result) {
+  var out = result.map(function(message) {
+    var output = chalk.cyan(message.file) + ' ';
+    output += chalk.red('[') + chalk.yellow('L' + message.lastLine) +
+      chalk.red(':') + chalk.yellow('C' + message.lastColumn) + chalk.red('] ');
+    output += message.message;
+    return output;
+  });
+  return out.join('\n');
+},
+
+// Select a reporter (if not using the default Grunt reporter)
+selectReporter = function (options) {
+  if (options.reporter === 'checkstyle') {
+    // Checkstyle XML reporter
+    options.reporter = '../lib/reporters/checkstyle.js';
+  } else if (options.reporter === 'json') {
+    // JSON reporter
+    options.reporter = '../lib/reporters/json.js';
+  } else if (options.reporter !== null && options.reporter !== undefined) {
+    // Custom reporter
+    options.reporter = path.resolve(process.cwd(), options.reporter);
+  }
+
+  var reporter;
+  if (options.reporter) {
+    reporter = require(options.reporter).reporter;
+  } else {
+    reporter = defaultReporter;
+  }
+
+  return reporter;
+};
+
+module.exports = {
+  defaultReporter: defaultReporter,
+  selectReporter: selectReporter
+};

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -30,7 +30,7 @@ selectReporter = function (options) {
 
   var reporter;
   if (options.reporter) {
-    reporter = require(options.reporter).reporter;
+    reporter = require(options.reporter);
   } else {
     reporter = defaultReporter;
   }

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -1,0 +1,76 @@
+/*
+ * Author: Josh Hagins
+ * https://github.com/jawshooah
+ *
+ * Modified from the original by: Boy Baukema
+ * https://github.com/relaxnow
+ */
+
+module.exports = {
+  reporter: function(results) {
+    "use strict";
+
+    var files = {},
+      out = [],
+      pairs = {
+        "&": "&amp;",
+        '"': "&quot;",
+        "'": "&apos;",
+        "<": "&lt;",
+        ">": "&gt;"
+      },
+      fileName, i, issue, severity, errorMessage;
+
+    function encode(s) {
+      for (var r in pairs) {
+        if (typeof(s) !== "undefined") {
+          s = s.replace(new RegExp(r, "g"), pairs[r]);
+        }
+      }
+      return s || "";
+    }
+
+    results.forEach(function(result) {
+      // Register the file
+      result.file = result.file.replace(/^\.\//, '');
+      if (!files[result.file]) {
+        files[result.file] = [];
+      }
+
+      // Add the error
+      files[result.file].push({
+        severity: result.type,
+        line: result.lastLine,
+        column: result.lastColumn,
+        message: result.message,
+        source: result.message  // vnu does not output error codes
+      });
+    });
+
+
+    out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>");
+
+    for (fileName in files) {
+      if (files.hasOwnProperty(fileName)) {
+        out.push("\t<file name=\"" + fileName + "\">");
+        for (i = 0; i < files[fileName].length; i++) {
+          issue = files[fileName][i];
+          out.push(
+            "\t\t<error " +
+              "line=\"" + issue.line + "\" " +
+              "column=\"" + issue.column + "\" " +
+              "severity=\"" + issue.severity + "\" " +
+              "message=\"" + encode(issue.message) + "\" " +
+              "source=\"" + encode(issue.source) + "\" " +
+              "/>"
+          );
+        }
+        out.push("\t</file>");
+      }
+    }
+
+    out.push("</checkstyle>");
+
+    console.log(out.join("\n"));
+  }
+};

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -6,10 +6,10 @@
  * https://github.com/relaxnow
  */
 
+'use strict';
+
 module.exports = {
   reporter: function(results) {
-    "use strict";
-
     var files = {},
       out = [],
       pairs = {

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -71,6 +71,6 @@ module.exports = {
 
     out.push("</checkstyle>");
 
-    console.log(out.join("\n"));
+    return out.join("\n");
   }
 };

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -42,8 +42,7 @@ module.exports = {
         severity: result.type,
         line: result.lastLine,
         column: result.lastColumn,
-        message: result.message,
-        source: result.message  // vnu does not output error codes
+        message: result.message
       });
     });
 
@@ -61,7 +60,6 @@ module.exports = {
               "column=\"" + issue.column + "\" " +
               "severity=\"" + issue.severity + "\" " +
               "message=\"" + encode(issue.message) + "\" " +
-              "source=\"" + encode(issue.source) + "\" " +
               "/>"
           );
         }

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -12,21 +12,21 @@ module.exports = function(results) {
   var files = {},
     out = [],
     pairs = {
-      "&": "&amp;",
-      '"': "&quot;",
-      "'": "&apos;",
-      "<": "&lt;",
-      ">": "&gt;"
+      '&': '&amp;',
+      '"': '&quot;',
+      '\'': '&apos;',
+      '<': '&lt;',
+      '>': '&gt;'
     },
     fileName, i, issue, severity, errorMessage;
 
   function encode(s) {
     for (var r in pairs) {
-      if (typeof(s) !== "undefined") {
-        s = s.replace(new RegExp(r, "g"), pairs[r]);
+      if (typeof(s) !== 'undefined') {
+        s = s.replace(new RegExp(r, 'g'), pairs[r]);
       }
     }
-    return s || "";
+    return s || '';
   }
 
   results.forEach(function(result) {
@@ -46,27 +46,27 @@ module.exports = function(results) {
   });
 
 
-  out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>");
+  out.push('<?xml version="1.0" encoding="utf-8"?><checkstyle>');
 
   for (fileName in files) {
     if (files.hasOwnProperty(fileName)) {
-      out.push("\t<file name=\"" + fileName + "\">");
+      out.push('\t<file name="' + fileName + '">');
       for (i = 0; i < files[fileName].length; i++) {
         issue = files[fileName][i];
         out.push(
-          "\t\t<error " +
-            "line=\"" + issue.line + "\" " +
-            "column=\"" + issue.column + "\" " +
-            "severity=\"" + issue.severity + "\" " +
-            "message=\"" + encode(issue.message) + "\" " +
-            "/>"
+          '\t\t<error ' +
+            'line="' + issue.line + '" ' +
+            'column="' + issue.column + '" ' +
+            'severity="' + issue.severity + '" ' +
+            'message="' + encode(issue.message) + '" ' +
+            '/>'
         );
       }
-      out.push("\t</file>");
+      out.push('\t</file>');
     }
   }
 
-  out.push("</checkstyle>");
+  out.push('</checkstyle>');
 
-  return out.join("\n");
+  return out.join('\n');
 };

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -8,67 +8,65 @@
 
 'use strict';
 
-module.exports = {
-  reporter: function(results) {
-    var files = {},
-      out = [],
-      pairs = {
-        "&": "&amp;",
-        '"': "&quot;",
-        "'": "&apos;",
-        "<": "&lt;",
-        ">": "&gt;"
-      },
-      fileName, i, issue, severity, errorMessage;
+module.exports = function(results) {
+  var files = {},
+    out = [],
+    pairs = {
+      "&": "&amp;",
+      '"': "&quot;",
+      "'": "&apos;",
+      "<": "&lt;",
+      ">": "&gt;"
+    },
+    fileName, i, issue, severity, errorMessage;
 
-    function encode(s) {
-      for (var r in pairs) {
-        if (typeof(s) !== "undefined") {
-          s = s.replace(new RegExp(r, "g"), pairs[r]);
-        }
-      }
-      return s || "";
-    }
-
-    results.forEach(function(result) {
-      // Register the file
-      result.file = result.file.replace(/^\.\//, '');
-      if (!files[result.file]) {
-        files[result.file] = [];
-      }
-
-      // Add the error
-      files[result.file].push({
-        severity: result.type,
-        line: result.lastLine,
-        column: result.lastColumn,
-        message: result.message
-      });
-    });
-
-
-    out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>");
-
-    for (fileName in files) {
-      if (files.hasOwnProperty(fileName)) {
-        out.push("\t<file name=\"" + fileName + "\">");
-        for (i = 0; i < files[fileName].length; i++) {
-          issue = files[fileName][i];
-          out.push(
-            "\t\t<error " +
-              "line=\"" + issue.line + "\" " +
-              "column=\"" + issue.column + "\" " +
-              "severity=\"" + issue.severity + "\" " +
-              "message=\"" + encode(issue.message) + "\" " +
-              "/>"
-          );
-        }
-        out.push("\t</file>");
+  function encode(s) {
+    for (var r in pairs) {
+      if (typeof(s) !== "undefined") {
+        s = s.replace(new RegExp(r, "g"), pairs[r]);
       }
     }
-
-    out.push("</checkstyle>");
-
-    return out.join("\n");
+    return s || "";
   }
+
+  results.forEach(function(result) {
+    // Register the file
+    result.file = result.file.replace(/^\.\//, '');
+    if (!files[result.file]) {
+      files[result.file] = [];
+    }
+
+    // Add the error
+    files[result.file].push({
+      severity: result.type,
+      line: result.lastLine,
+      column: result.lastColumn,
+      message: result.message
+    });
+  });
+
+
+  out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle>");
+
+  for (fileName in files) {
+    if (files.hasOwnProperty(fileName)) {
+      out.push("\t<file name=\"" + fileName + "\">");
+      for (i = 0; i < files[fileName].length; i++) {
+        issue = files[fileName][i];
+        out.push(
+          "\t\t<error " +
+            "line=\"" + issue.line + "\" " +
+            "column=\"" + issue.column + "\" " +
+            "severity=\"" + issue.severity + "\" " +
+            "message=\"" + encode(issue.message) + "\" " +
+            "/>"
+        );
+      }
+      out.push("\t</file>");
+    }
+  }
+
+  out.push("</checkstyle>");
+
+  return out.join("\n");
 };

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -5,12 +5,10 @@
 
 'use strict';
 
-module.exports  = {
-  reporter: function(results) {
-    results.forEach(function(result) {
-      // result already has 'file' property, 'url' is redundant
-      delete result.url;
-    });
-    return JSON.stringify(results);
-  }
+module.exports = function(results) {
+  results.forEach(function(result) {
+    // result already has 'file' property, 'url' is redundant
+    delete result.url;
+  });
+  return JSON.stringify(results);
 };

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -3,6 +3,8 @@
  * https://github.com/jawshooah
  */
 
+'use strict';
+
 module.exports  = {
   reporter: function(results) {
     results.forEach(function(result) {

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -1,0 +1,14 @@
+/*
+ * Author: Josh Hagins
+ * https://github.com/jawshooah
+ */
+
+module.exports  = {
+  reporter: function(results) {
+    results.forEach(function(result) {
+      // result already has 'file' property, 'url' is redundant
+      delete result.url;
+    });
+    console.log(JSON.stringify(results));
+  }
+};

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -9,6 +9,6 @@ module.exports  = {
       // result already has 'file' property, 'url' is redundant
       delete result.url;
     });
-    console.log(JSON.stringify(results));
+    return JSON.stringify(results);
   }
 };

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "chalk": "1.0.0",
-    "hooker": "^0.2.3"
+    "chalk": "1.0.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "chalk": "1.0.0"
+    "chalk": "1.0.0",
+    "hooker": "^0.2.3"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "0.11.0",
-    "grunt-contrib-nodeunit": "0.4.1"
+    "grunt-contrib-nodeunit": "0.4.1",
+    "nodeunit": "^0.9.1",
+    "stripcolorcodes": "^0.1.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "0.11.0",
     "grunt-contrib-nodeunit": "0.4.1",
-    "nodeunit": "^0.9.1",
     "stripcolorcodes": "^0.1.0"
   },
   "peerDependencies": {

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -30,20 +30,15 @@ module.exports = function(grunt) {
 
     // Select a reporter (if not using the default Grunt reporter)
     selectReporter = function(options) {
-      switch (true) {
-        // Checkstyle (XML) reporter
-        case options.reporter === 'checkstyle':
-          options.reporter = '../lib/reporters/checkstyle.js';
-          break;
-
+      if (options.reporter === 'checkstyle') {
+        // Checkstyle XML reporter
+        options.reporter = '../lib/reporters/checkstyle.js';
+      } else if (options.reporter === 'json') {
         // JSON reporter
-        case options.reporter === 'json':
-          options.reporter = '../lib/reporters/json.js';
-          break;
-
+        options.reporter = '../lib/reporters/json.js';
+      } else if (options.reporter != null) {
         // Custom reporter
-        case options.reporter != null:
-          options.reporter = path.resolve(process.cwd(), options.reporter);
+        options.reporter = path.resolve(process.cwd(), options.reporter);
       }
 
       var reporter;

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -64,7 +64,8 @@ module.exports = function(grunt) {
       files = grunt.file.expand(this.filesSrc),
       options = this.options({
         files: files,
-        force: false
+        force: false,
+        absoluteFilePathsForReporter: false
       }),
       force = options.force,
       reporter = selectReporter(options),

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -8,11 +8,56 @@
 
 'use strict';
 
+var path = require('path');
+var chalk = require('chalk');
+var hooker = require('hooker');
 var htmllint = require('../lib/htmllint');
 
 module.exports = function(grunt) {
 
-  var chalk = require('chalk');
+  var usingDefaultReporter,
+
+    // Default Grunt reporter
+    defaultReporter = function(result) {
+      result.forEach(function(message) {
+        var output = chalk.cyan(message.file) + ' ';
+        output += chalk.red('[') + chalk.yellow('L' + message.lastLine) +
+          chalk.red(':') + chalk.yellow('C' + message.lastColumn) + chalk.red('] ');
+        output += message.message;
+        grunt.log.writeln(output);
+      });
+    },
+
+    // Select a reporter (if not using the default Grunt reporter)
+    selectReporter = function(options) {
+      switch (true) {
+        // Checkstyle (XML) reporter
+        case options.reporter === 'checkstyle':
+          options.reporter = '../lib/reporters/checkstyle.js';
+          break;
+
+        // Custom reporter
+        case options.reporter != null:
+          options.reporter = path.resolve(process.cwd(), options.reporter);
+      }
+
+      var reporter;
+      if (options.reporter) {
+        try {
+          reporter = require(options.reporter).reporter;
+          usingDefaultReporter = false;
+        } catch (err) {
+          grunt.fatal(err);
+        }
+      }
+
+      if (!reporter) {
+        reporter = defaultReporter;
+        usingDefaultReporter = true;
+      }
+
+      return reporter;
+    };
 
   grunt.registerMultiTask('htmllint', 'Validate html files', function() {
     var done = this.async(),
@@ -21,28 +66,54 @@ module.exports = function(grunt) {
         files: files,
         force: false
       }),
-      force = options.force;
+      force = options.force,
+      reporter = selectReporter(options),
+      reporterOutput = options.reporterOutput,
+      output;
+
+    // Hook into stdout to capture report
+    if (reporterOutput) {
+      output = '';
+      hooker.hook(process.stdout, 'write', {
+        pre: function(out) {
+          output += out;
+          return hooker.preempt();
+        }
+      });
+    }
 
     htmllint(options, function(error, result) {
+      var passed = true;
       if (error) {
+        passed = force;
         grunt.log.error(error);
-        done(force);
-        return;
       }
-      if (!result.length) {
-        grunt.log.ok(files.length + ' file' + (files.length === 1 ? '' : 's') + ' lint free.');
-        done();
-        return;
+      else if (!result.length) {
+        if (usingDefaultReporter) {
+          grunt.log.ok(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' lint free.');
+        }
       } else {
-        result.forEach(function(message) {
-          var output = chalk.cyan(message.file) + ' ';
-          output += chalk.red('[') + chalk.yellow('L' + message.lastLine) +
-            chalk.red(':') + chalk.yellow('C' + message.lastColumn) + chalk.red('] ');
-          output += message.message;
-          grunt.log.writeln(output);
-        });
+        passed = force;
+        reporter(result);
+        if (usingDefaultReporter) {
+          grunt.log.error(result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
+                          files.length + ' ' + grunt.util.pluralize(files.length, 'file/files'));
+        }
       }
-      done(force);
+
+      // Write the output of the reporter if wanted
+      if (reporterOutput) {
+        hooker.unhook(process.stdout, 'write');
+        reporterOutput = grunt.template.process(reporterOutput);
+        var destDir = path.dirname(reporterOutput);
+        if (!grunt.file.exists(destDir)) {
+          grunt.file.mkdir(destDir);
+        }
+        grunt.file.write(reporterOutput, output);
+        grunt.log.ok('Report "' + reporterOutput + '" created.');
+      }
+
+      done(passed);
     });
   });
 

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -36,6 +36,11 @@ module.exports = function(grunt) {
           options.reporter = '../lib/reporters/checkstyle.js';
           break;
 
+        // JSON reporter
+        case options.reporter === 'json':
+          options.reporter = '../lib/reporters/json.js';
+          break;
+
         // Custom reporter
         case options.reporter != null:
           options.reporter = path.resolve(process.cwd(), options.reporter);

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var path = require('path');
-var chalk = require('chalk');
 var htmllint = require('../lib/htmllint');
 var reporters = require('../lib/reporters');
 

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -47,9 +47,9 @@ module.exports = function(grunt) {
         output = reporter(result);
         if (!reporterOutput) {
           grunt.log.writeln(output);
-          grunt.log.error(result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
-                          files.length + ' ' + grunt.util.pluralize(files.length, 'file/files'));
         }
+        grunt.log.error(result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
+                        files.length + ' ' + grunt.util.pluralize(files.length, 'file/files'));
       }
 
       // Write the output of the reporter if wanted

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -28,7 +28,8 @@ module.exports = function(grunt) {
 
     htmllint(options, function(error, result) {
       var passed = true,
-        output;
+        output,
+        uniqueFiles;
 
       try {
         reporter = reporters.selectReporter(options);
@@ -48,8 +49,16 @@ module.exports = function(grunt) {
         if (!reporterOutput) {
           grunt.log.writeln(output);
         }
-        grunt.log.error(result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
-                        files.length + ' ' + grunt.util.pluralize(files.length, 'file/files'));
+        uniqueFiles = result
+          .map(function(elem) {
+            return elem.file;
+          })
+          .filter(function(file, index, resultFiles) {
+            return resultFiles.indexOf(file) === index;
+          });
+        grunt.log.error(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' checked, ' +
+                        result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
+                        uniqueFiles.length + ' ' + grunt.util.pluralize(uniqueFiles.length, 'file/files'));
       }
 
       // Write the output of the reporter if wanted

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -29,8 +29,7 @@ module.exports = function(grunt) {
 
     htmllint(options, function(error, result) {
       var passed = true,
-        output = '',
-        usingDefaultReporter = !options.reporter;
+        output;
 
       try {
         reporter = reporters.selectReporter(options);
@@ -43,13 +42,11 @@ module.exports = function(grunt) {
         grunt.log.error(error);
       }
       else if (!result.length) {
-        if (usingDefaultReporter) {
-          grunt.log.ok(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' lint free.');
-        }
+        grunt.log.ok(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' lint free.');
       } else {
         passed = force;
         output = reporter(result);
-        if (usingDefaultReporter) {
+        if (!reporterOutput) {
           grunt.log.writeln(output);
           grunt.log.error(result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
                           files.length + ' ' + grunt.util.pluralize(files.length, 'file/files'));

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 var path = require('path');
-var checkstyle = require('../lib/reporters/checkstyle');
+var reporter = require('../lib/reporters/checkstyle');
 
 exports.reporters = {
   'checkstyle reporter': {
     'when given empty result': function(test) {
       var result = [],
-        reporter = checkstyle.reporter,
         expected = '<?xml version="1.0" encoding="utf-8"?><checkstyle>\n</checkstyle>',
         actual = reporter(result);
       test.equal(actual, expected, 'Should return empty checkstyle XML for empty result');
@@ -28,7 +27,6 @@ exports.reporters = {
           message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
           file: invalid_html
         }],
-        reporter = checkstyle.reporter,
         expected = [
           '<?xml version="1.0" encoding="utf-8"?><checkstyle>',
           '\t<file name="test/invalid.html">',

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -32,8 +32,8 @@ exports.reporters = {
         expected = [
           '<?xml version="1.0" encoding="utf-8"?><checkstyle>',
           '\t<file name="test/invalid.html">',
-          '\t\t<error line="1" column="16" severity="error" message="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." source="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." />',
-          '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." source="Attribute “unknownattr” not allowed on element “img” at this point." />',
+          '\t\t<error line="1" column="16" severity="error" message="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." />',
+          '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." />',
           '\t</file>',
           '</checkstyle>'
         ].join("\n"),

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 var path = require('path');
-var testCase  = require('nodeunit').testCase;
 var checkstyle = require('../lib/reporters/checkstyle');
 
-exports.reporters = testCase({
-  'checkstyle reporter': testCase({
+exports.reporters = {
+  'checkstyle reporter': {
     'when given empty result': function(test) {
       var result = [],
         reporter = checkstyle.reporter,
@@ -42,5 +41,5 @@ exports.reporters = testCase({
       test.equal(actual, expected, 'Should report errors as checkstyle XML');
       test.done();
     }
-  })
-});
+  }
+};

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var path = require('path');
+var testCase  = require('nodeunit').testCase;
+var checkstyle = require('../lib/reporters/checkstyle');
+
+exports.reporters = testCase({
+  'checkstyle reporter': testCase({
+    'when given empty result': function(test) {
+      var result = [],
+        reporter = checkstyle.reporter,
+        expected = '<?xml version="1.0" encoding="utf-8"?><checkstyle>\n</checkstyle>',
+        actual = reporter(result);
+      test.equal(actual, expected, 'Should return empty checkstyle XML for empty result');
+      test.done();
+    },
+    'when given non-empty result': function(test) {
+      var invalid_html = path.join('test', 'invalid.html'),
+        result = [{
+          lastLine: 1,
+          lastColumn: 16,
+          type: 'error',
+          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          file: invalid_html
+        }, {
+          lastLine: 9,
+          lastColumn: 96,
+          type: 'error',
+          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+          file: invalid_html
+        }],
+        reporter = checkstyle.reporter,
+        expected = [
+          '<?xml version="1.0" encoding="utf-8"?><checkstyle>',
+          '\t<file name="test/invalid.html">',
+          '\t\t<error line="1" column="16" severity="error" message="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." source="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." />',
+          '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." source="Attribute “unknownattr” not allowed on element “img” at this point." />',
+          '\t</file>',
+          '</checkstyle>'
+        ].join("\n"),
+        actual = reporter(result);
+      test.equal(actual, expected, 'Should report errors as checkstyle XML');
+      test.done();
+    }
+  })
+});

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -3,7 +3,7 @@
 var reporter = require('../lib/reporters/checkstyle');
 var expectedResults = require('./support/expected_results');
 
-exports.reporters = {
+exports.checkstyle = {
   'checkstyle reporter': {
     'when given empty result': function(test) {
       var result = [],

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var path = require('path');
 var reporter = require('../lib/reporters/checkstyle');
+var expectedResults = require('./support/expected_results');
 
 exports.reporters = {
   'checkstyle reporter': {
@@ -13,28 +13,17 @@ exports.reporters = {
       test.done();
     },
     'when given non-empty result': function(test) {
-      var invalid_html = path.join('test', 'invalid.html'),
-        result = [{
-          lastLine: 1,
-          lastColumn: 16,
-          type: 'error',
-          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          file: invalid_html
-        }, {
-          lastLine: 9,
-          lastColumn: 96,
-          type: 'error',
-          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-          file: invalid_html
-        }],
+      var result = expectedResults['invalid.html'],
         expected = [
           '<?xml version="1.0" encoding="utf-8"?><checkstyle>',
           '\t<file name="test/invalid.html">',
           '\t\t<error line="1" column="16" severity="error" message="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." />',
           '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." />',
+          '\t\t<error line="9" column="96" severity="error" message="An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images." />',
+          '\t\t<error line="11" column="19" severity="error" message="The “clear” attribute on the “br” element is obsolete. Use CSS instead." />',
           '\t</file>',
           '</checkstyle>'
-        ].join("\n"),
+        ].join('\n'),
         actual = reporter(result);
       test.equal(actual, expected, 'Should report errors as checkstyle XML');
       test.done();

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var path = require('path');
+var testCase = require('nodeunit').testCase;
 var htmllint = require('../lib/htmllint');
 
 function run(test, config, expected, message) {
@@ -25,37 +26,70 @@ function run(test, config, expected, message) {
   });
 }
 
-exports.htmllint = {
-  'all': function(test) {
-    run(test, {
-      files: ['test/valid.html', 'test/invalid.html']
-    }, [
-      {
-        lastLine: 1,
-        lastColumn: 16,
-        message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-        file: path.join('test', 'invalid.html')
-      },
-      {
-        lastLine: 9,
-        lastColumn: 96,
-        message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-        file: path.join('test', 'invalid.html')
-      },
-      {
-        lastLine: 9,
-        lastColumn: 96,
-        message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
-        file: path.join('test', 'invalid.html')
-      },
-      {
-        lastLine: 11,
-        lastColumn: 19,
-        message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
-        file: path.join('test', 'invalid.html')
-      }
-    ], 'four errors from test/invalid.html');
-  },
+exports.htmllint = testCase({
+  'all': testCase({
+    'with relative paths': function(test) {
+      run(test, {
+        files: ['test/valid.html', 'test/invalid.html']
+      }, [
+        {
+          lastLine: 1,
+          lastColumn: 16,
+          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          file: path.join('test', 'invalid.html')
+        },
+        {
+          lastLine: 9,
+          lastColumn: 96,
+          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+          file: path.join('test', 'invalid.html')
+        },
+        {
+          lastLine: 9,
+          lastColumn: 96,
+          message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+          file: path.join('test', 'invalid.html')
+        },
+        {
+          lastLine: 11,
+          lastColumn: 19,
+          message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
+          file: path.join('test', 'invalid.html')
+        }
+      ], 'four errors from test/invalid.html');
+    },
+    'with absolute paths': function(test) {
+      run(test, {
+        files: ['test/valid.html', 'test/invalid.html'],
+        absoluteFilePathsForReporter: true
+      }, [
+        {
+          lastLine: 1,
+          lastColumn: 16,
+          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          file: path.resolve(path.join('test', 'invalid.html'))
+        },
+        {
+          lastLine: 9,
+          lastColumn: 96,
+          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+          file: path.resolve(path.join('test', 'invalid.html'))
+        },
+        {
+          lastLine: 9,
+          lastColumn: 96,
+          message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+          file: path.resolve(path.join('test', 'invalid.html'))
+        },
+        {
+          lastLine: 11,
+          lastColumn: 19,
+          message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
+          file: path.resolve(path.join('test', 'invalid.html'))
+        }
+      ], 'four errors from test/invalid.html');
+    }
+  }),
   'ignore': function(test) {
     run(test, {
       ignore: [
@@ -73,4 +107,4 @@ exports.htmllint = {
       }
     ], 'one error from test/invalid.html, other three were ignored');
   }
-};
+});

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var path = require('path');
-var testCase = require('nodeunit').testCase;
 var htmllint = require('../lib/htmllint');
 
 function run(test, config, expected, message) {
@@ -26,8 +25,8 @@ function run(test, config, expected, message) {
   });
 }
 
-exports.htmllint = testCase({
-  'all': testCase({
+exports.htmllint = {
+  'all': {
     'with relative paths': function(test) {
       run(test, {
         files: ['test/valid.html', 'test/invalid.html']
@@ -89,7 +88,7 @@ exports.htmllint = testCase({
         }
       ], 'four errors from test/invalid.html');
     }
-  }),
+  },
   'ignore': function(test) {
     run(test, {
       ignore: [
@@ -107,4 +106,4 @@ exports.htmllint = testCase({
       }
     ], 'one error from test/invalid.html, other three were ignored');
   }
-});
+};

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var htmllint = require('../lib/htmllint');
+var expectedResults = require('./support/expected_results');
 
 function run(test, config, expected, message) {
   test.expect(1);
@@ -15,6 +16,7 @@ function run(test, config, expected, message) {
     result = result.map(function(msg) {
       return {
         file: msg.file,
+        type: msg.type,
         message: msg.message,
         lastLine: msg.lastLine,
         lastColumn: msg.lastColumn
@@ -28,65 +30,25 @@ function run(test, config, expected, message) {
 exports.htmllint = {
   'all': {
     'with relative paths': function(test) {
+      var expected = expectedResults['invalid.html'];
       run(test, {
         files: ['test/valid.html', 'test/invalid.html']
-      }, [
-        {
-          lastLine: 1,
-          lastColumn: 16,
-          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          file: path.join('test', 'invalid.html')
-        },
-        {
-          lastLine: 9,
-          lastColumn: 96,
-          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-          file: path.join('test', 'invalid.html')
-        },
-        {
-          lastLine: 9,
-          lastColumn: 96,
-          message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
-          file: path.join('test', 'invalid.html')
-        },
-        {
-          lastLine: 11,
-          lastColumn: 19,
-          message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
-          file: path.join('test', 'invalid.html')
-        }
-      ], 'four errors from test/invalid.html');
+      }, expected, 'four errors from test/invalid.html');
     },
     'with absolute paths': function(test) {
+      var expected = expectedResults['invalid.html'].map(function(result) {
+        return {
+          file: path.resolve(result.file),
+          type: result.type,
+          message: result.message,
+          lastLine: result.lastLine,
+          lastColumn: result.lastColumn
+        };
+      });
       run(test, {
         files: ['test/valid.html', 'test/invalid.html'],
         absoluteFilePathsForReporter: true
-      }, [
-        {
-          lastLine: 1,
-          lastColumn: 16,
-          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          file: path.resolve(path.join('test', 'invalid.html'))
-        },
-        {
-          lastLine: 9,
-          lastColumn: 96,
-          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-          file: path.resolve(path.join('test', 'invalid.html'))
-        },
-        {
-          lastLine: 9,
-          lastColumn: 96,
-          message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
-          file: path.resolve(path.join('test', 'invalid.html'))
-        },
-        {
-          lastLine: 11,
-          lastColumn: 19,
-          message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
-          file: path.resolve(path.join('test', 'invalid.html'))
-        }
-      ], 'four errors from test/invalid.html');
+      }, expected, 'four errors from test/invalid.html');
     }
   },
   'ignore': function(test) {
@@ -101,6 +63,7 @@ exports.htmllint = {
       {
         lastLine: 9,
         lastColumn: 96,
+        type: 'error',
         message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
         file: path.join('test', 'invalid.html')
       }

--- a/test/json_test.js
+++ b/test/json_test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 var path = require('path');
-var json = require('../lib/reporters/json');
+var reporter = require('../lib/reporters/json');
 
 exports.reporters = {
   'json reporter': {
     'when given empty result': function(test) {
       var result = [],
-        reporter = json.reporter,
         expected = '[]',
         actual = reporter(result);
       test.equal(actual, expected, 'Should return empty json array for empty result');
@@ -28,7 +27,6 @@ exports.reporters = {
           message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
           file: invalid_html
         }],
-        reporter = json.reporter,
         expected = JSON.stringify(result),
         actual = reporter(result);
       test.equal(actual, expected, 'Should report errors as json array');

--- a/test/json_test.js
+++ b/test/json_test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 var path = require('path');
-var testCase  = require('nodeunit').testCase;
 var json = require('../lib/reporters/json');
 
-exports.reporters = testCase({
-  'json reporter': testCase({
+exports.reporters = {
+  'json reporter': {
     'when given empty result': function(test) {
       var result = [],
         reporter = json.reporter,
@@ -35,5 +34,5 @@ exports.reporters = testCase({
       test.equal(actual, expected, 'Should report errors as json array');
       test.done();
     }
-  })
-});
+  }
+};

--- a/test/json_test.js
+++ b/test/json_test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var path = require('path');
+var testCase  = require('nodeunit').testCase;
+var json = require('../lib/reporters/json');
+
+exports.reporters = testCase({
+  'json reporter': testCase({
+    'when given empty result': function(test) {
+      var result = [],
+        reporter = json.reporter,
+        expected = '[]',
+        actual = reporter(result);
+      test.equal(actual, expected, 'Should return empty json array for empty result');
+      test.done();
+    },
+    'when given non-empty result': function(test) {
+      var invalid_html = path.join('test', 'invalid.html'),
+        result = [{
+          lastLine: 1,
+          lastColumn: 16,
+          type: 'error',
+          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          file: invalid_html
+        }, {
+          lastLine: 9,
+          lastColumn: 96,
+          type: 'error',
+          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+          file: invalid_html
+        }],
+        reporter = json.reporter,
+        expected = JSON.stringify(result),
+        actual = reporter(result);
+      test.equal(actual, expected, 'Should report errors as json array');
+      test.done();
+    }
+  })
+});

--- a/test/json_test.js
+++ b/test/json_test.js
@@ -3,7 +3,7 @@
 var reporter = require('../lib/reporters/json');
 var expectedResults = require('./support/expected_results');
 
-exports.reporters = {
+exports.json = {
   'json reporter': {
     'when given empty result': function(test) {
       var result = [],

--- a/test/json_test.js
+++ b/test/json_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var path = require('path');
 var reporter = require('../lib/reporters/json');
+var expectedResults = require('./support/expected_results');
 
 exports.reporters = {
   'json reporter': {
@@ -13,20 +13,7 @@ exports.reporters = {
       test.done();
     },
     'when given non-empty result': function(test) {
-      var invalid_html = path.join('test', 'invalid.html'),
-        result = [{
-          lastLine: 1,
-          lastColumn: 16,
-          type: 'error',
-          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          file: invalid_html
-        }, {
-          lastLine: 9,
-          lastColumn: 96,
-          type: 'error',
-          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-          file: invalid_html
-        }],
+      var result = expectedResults['invalid.html'],
         expected = JSON.stringify(result),
         actual = reporter(result);
       test.equal(actual, expected, 'Should report errors as json array');

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -49,7 +49,7 @@ exports.reporters = {
         reporter: 'checkstyle'
       },
         reporter = reporters.selectReporter(options),
-        checkstyleReporter = require('../lib/reporters/checkstyle').reporter;
+        checkstyleReporter = require('../lib/reporters/checkstyle');
       test.equal(reporter, checkstyleReporter, 'Should return checkstyle reporter');
       test.done();
     },
@@ -58,7 +58,7 @@ exports.reporters = {
         reporter: 'json'
       },
         reporter = reporters.selectReporter(options),
-        jsonReporter = require('../lib/reporters/json').reporter;
+        jsonReporter = require('../lib/reporters/json');
       test.equal(reporter, jsonReporter, 'Should return json reporter');
       test.done();
     },
@@ -67,7 +67,7 @@ exports.reporters = {
         reporter: 'test/support/custom_reporter.js'
       },
         reporter = reporters.selectReporter(options),
-        customReporter = require('./support/custom_reporter').reporter;
+        customReporter = require('./support/custom_reporter');
       test.equal(reporter, customReporter, 'Should return custom reporter');
       test.done();
     },

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -15,7 +15,7 @@ exports.reporters = testCase({
       test.equal(actual, expected, 'Should return empty String for empty result');
       test.done();
     },
-    'when given non-empty result': function (test) {
+    'when given non-empty result': function(test) {
       var result = [{
         lastLine: 1,
         lastColumn: 16,
@@ -34,6 +34,53 @@ exports.reporters = testCase({
         ].join("\n"),
         actual = stripColorCodes(reporter(result));
       test.equal(actual, expected, 'Should report errors as a String');
+      test.done();
+    }
+  }),
+  'selectReporter': testCase({
+    'when no reporter is specified': function(test) {
+      var options = {},
+        reporter = reporters.selectReporter(options);
+      test.equal(reporter, reporters.defaultReporter, 'Should return default reporter');
+      test.done();
+    },
+    'when checkstyle reporter is specified': function(test) {
+      var options = {
+        reporter: 'checkstyle'
+      },
+        reporter = reporters.selectReporter(options),
+        checkstyleReporter = require('../lib/reporters/checkstyle').reporter;
+      test.equal(reporter, checkstyleReporter, 'Should return checkstyle reporter');
+      test.done();
+    },
+    'when json reporter is specified': function(test) {
+      var options = {
+        reporter: 'json'
+      },
+        reporter = reporters.selectReporter(options),
+        jsonReporter = require('../lib/reporters/json').reporter;
+      test.equal(reporter, jsonReporter, 'Should return json reporter');
+      test.done();
+    },
+    'when valid custom reporter is specified': function(test) {
+      var options = {
+        reporter: 'test/support/custom_reporter.js'
+      },
+        reporter = reporters.selectReporter(options),
+        customReporter = require('./support/custom_reporter').reporter;
+      test.equal(reporter, customReporter, 'Should return custom reporter');
+      test.done();
+    },
+    'when invalid custom reporter is specified': function(test) {
+      var options = {
+        reporter: 'does/not/exist.js'
+      };
+      test.throws(
+        function() {
+          reporters.selectReporter(options);
+        },
+        Error, 'Should throw an error'
+      );
       test.done();
     }
   })

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -16,21 +16,22 @@ exports.reporters = testCase({
       test.done();
     },
     'when given non-empty result': function(test) {
-      var result = [{
-        lastLine: 1,
-        lastColumn: 16,
-        message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-        file: path.join('test', 'invalid.html')
-      }, {
-        lastLine: 9,
-        lastColumn: 96,
-        message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-        file: path.join('test', 'invalid.html')
-      }],
+      var invalid_html = path.join('test', 'invalid.html'),
+        result = [{
+          lastLine: 1,
+          lastColumn: 16,
+          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          file: invalid_html
+        }, {
+          lastLine: 9,
+          lastColumn: 96,
+          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+          file: invalid_html
+        }],
         reporter = reporters.defaultReporter,
         expected = [
-          'test/invalid.html [L1:C16] Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          'test/invalid.html [L9:C96] Attribute “unknownattr” not allowed on element “img” at this point.'
+          invalid_html + ' [L1:C16] Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          invalid_html + ' [L9:C96] Attribute “unknownattr” not allowed on element “img” at this point.'
         ].join("\n"),
         actual = stripColorCodes(reporter(result));
       test.equal(actual, expected, 'Should report errors as a String');

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var stripColorCodes = require('stripcolorcodes');
 var reporters = require('../lib/reporters');
+var expectedResults = require('./support/expected_results');
 
 exports.reporters = {
   'defaultReporter': {
@@ -10,28 +11,20 @@ exports.reporters = {
       var result = [],
         reporter = reporters.defaultReporter,
         expected = '',
-        actual = stripColorCodes(reporter(result));
+        actual = reporter(result);
       test.equal(actual, expected, 'Should return empty String for empty result');
       test.done();
     },
     'when given non-empty result': function(test) {
       var invalid_html = path.join('test', 'invalid.html'),
-        result = [{
-          lastLine: 1,
-          lastColumn: 16,
-          message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          file: invalid_html
-        }, {
-          lastLine: 9,
-          lastColumn: 96,
-          message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
-          file: invalid_html
-        }],
+        result = expectedResults['invalid.html'],
         reporter = reporters.defaultReporter,
         expected = [
           invalid_html + ' [L1:C16] Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          invalid_html + ' [L9:C96] Attribute “unknownattr” not allowed on element “img” at this point.'
-        ].join("\n"),
+          invalid_html + ' [L9:C96] Attribute “unknownattr” not allowed on element “img” at this point.',
+          invalid_html + ' [L9:C96] An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+          invalid_html + ' [L11:C19] The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
+        ].join('\n'),
         actual = stripColorCodes(reporter(result));
       test.equal(actual, expected, 'Should report errors as a String');
       test.done();

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -2,11 +2,10 @@
 
 var path = require('path');
 var stripColorCodes = require('stripcolorcodes');
-var testCase  = require('nodeunit').testCase;
 var reporters = require('../lib/reporters');
 
-exports.reporters = testCase({
-  'defaultReporter': testCase({
+exports.reporters = {
+  'defaultReporter': {
     'when given empty result': function(test) {
       var result = [],
         reporter = reporters.defaultReporter,
@@ -37,8 +36,8 @@ exports.reporters = testCase({
       test.equal(actual, expected, 'Should report errors as a String');
       test.done();
     }
-  }),
-  'selectReporter': testCase({
+  },
+  'selectReporter': {
     'when no reporter is specified': function(test) {
       var options = {},
         reporter = reporters.selectReporter(options);
@@ -84,5 +83,5 @@ exports.reporters = testCase({
       );
       test.done();
     }
-  })
-});
+  }
+};

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var path = require('path');
+var stripColorCodes = require('stripcolorcodes');
+var testCase  = require('nodeunit').testCase;
+var reporters = require('../lib/reporters');
+
+exports.reporters = testCase({
+  'defaultReporter': testCase({
+    'when given empty result': function(test) {
+      var result = [],
+        reporter = reporters.defaultReporter,
+        expected = '',
+        actual = stripColorCodes(reporter(result));
+      test.equal(actual, expected, 'Should return empty String for empty result');
+      test.done();
+    },
+    'when given non-empty result': function (test) {
+      var result = [{
+        lastLine: 1,
+        lastColumn: 16,
+        message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+        file: path.join('test', 'invalid.html')
+      }, {
+        lastLine: 9,
+        lastColumn: 96,
+        message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+        file: path.join('test', 'invalid.html')
+      }],
+        reporter = reporters.defaultReporter,
+        expected = [
+          'test/invalid.html [L1:C16] Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          'test/invalid.html [L9:C96] Attribute “unknownattr” not allowed on element “img” at this point.'
+        ].join("\n"),
+        actual = stripColorCodes(reporter(result));
+      test.equal(actual, expected, 'Should report errors as a String');
+      test.done();
+    }
+  })
+});

--- a/test/support/custom_reporter.js
+++ b/test/support/custom_reporter.js
@@ -1,7 +1,5 @@
 'use strict';
 
-module.exports  = {
-  reporter: function(results) {
-    return '';
-  }
+module.exports = function(results) {
+  return '';
 };

--- a/test/support/custom_reporter.js
+++ b/test/support/custom_reporter.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports  = {
+  reporter: function(results) {
+    return '';
+  }
+};

--- a/test/support/expected_results.js
+++ b/test/support/expected_results.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var path = require('path');
+var invalid_html = path.join('test', 'invalid.html');
+
+module.exports = {
+  'invalid.html': [
+    {
+      lastLine: 1,
+      lastColumn: 16,
+      type: 'error',
+      message: 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+      file: invalid_html
+    },
+    {
+      lastLine: 9,
+      lastColumn: 96,
+      type: 'error',
+      message: 'Attribute “unknownattr” not allowed on element “img” at this point.',
+      file: invalid_html
+    },
+    {
+      lastLine: 9,
+      lastColumn: 96,
+      type: 'error',
+      message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+      file: invalid_html
+    },
+    {
+      lastLine: 11,
+      lastColumn: 19,
+      type: 'error',
+      message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
+      file: invalid_html
+    }
+  ]
+};


### PR DESCRIPTION
Also add related `reporterOutput` and `absolutePathsForReporter` options
to configure the location for generated output and whether it should use
absolute paths rather than relative.

Closes #42.