### PR TITLE
Refactor Grunt targets.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,30 +1,39 @@
 module.exports = function(grunt) {
-  "use strict";
+  'use strict';
 
   // Project configuration.
   grunt.initConfig({
+
     htmllint: {
-      valid: "test/valid.html",
-      invalid: "test/*.html",
+      valid: 'test/valid.html',
+      force: {
+        options: {
+          force: true
+        },
+        src: 'test/*.html'
+      },
       ignore: {
         options: {
-          ignore: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
+          ignore: [
+            'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+            'Attribute “unknownattr” not allowed on element “img” at this point.',
+            'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+            'The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
+          ]
         },
-        src: "test/*.html"
+        src: 'test/*.html'
       }
     },
+
     nodeunit: {
-      files: ['test/**/*.js']
+      files: 'test/*.js'
     },
+
     jshint: {
-      files: ['Grunfile.js', 'tasks/**/*.js', 'test/**/*.js'],
       options: {
-        jshintrc: ".jshintrc"
-      }
-    },
-    watch: {
-      files: '<config:lint.files>',
-      tasks: 'default'
+        jshintrc: '.jshintrc'
+      },
+      files: ['Grunfile.js', 'lib/*.js', 'tasks/*.js', 'test/*.js']
     }
   });
 
@@ -32,6 +41,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
-  grunt.registerTask('default', ['jshint', 'nodeunit']);
+  grunt.registerTask('default', ['jshint', 'nodeunit', 'htmllint']);
+  grunt.registerTask('test', 'default');
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,27 +4,6 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
 
-    htmllint: {
-      valid: 'test/valid.html',
-      force: {
-        options: {
-          force: true
-        },
-        src: 'test/*.html'
-      },
-      ignore: {
-        options: {
-          ignore: [
-            'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
-            'Attribute “unknownattr” not allowed on element “img” at this point.',
-            'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-            'The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
-          ]
-        },
-        src: 'test/*.html'
-      }
-    },
-
     nodeunit: {
       files: 'test/*.js'
     },
@@ -41,7 +20,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
-  grunt.registerTask('default', ['jshint', 'nodeunit', 'htmllint']);
+  grunt.registerTask('default', ['jshint', 'nodeunit']);
   grunt.registerTask('test', 'default');
 
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": "*"
   },
   "scripts": {
-    "test": "grunt"
+    "test": "grunt test"
   },
   "dependencies": {
     "async": "0.2.10",


### PR DESCRIPTION
* Add lib to JSHint
* Run htmlint own task by default
* Remove non existent `watch` target
* Add a test target (alias for default atm)