### PR TITLE
Add "source" attribute to errors in checkstyle XML

### DIFF
--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -41,7 +41,8 @@ module.exports = function(results) {
       severity: result.type,
       line: result.lastLine,
       column: result.lastColumn,
-      message: result.message
+      message: result.message,
+      source: 'htmllint.Validation' + (result.type === 'error' ? 'Error' : 'Warning')
     });
   });
 
@@ -59,6 +60,7 @@ module.exports = function(results) {
             'column="' + issue.column + '" ' +
             'severity="' + issue.severity + '" ' +
             'message="' + encode(issue.message) + '" ' +
+            'source="' + issue.source + '" ' +
             '/>'
         );
       }

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -17,10 +17,10 @@ exports.checkstyle = {
         expected = [
           '<?xml version="1.0" encoding="utf-8"?><checkstyle>',
           '\t<file name="test/invalid.html">',
-          '\t\t<error line="1" column="16" severity="error" message="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." />',
-          '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." />',
-          '\t\t<error line="9" column="96" severity="error" message="An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images." />',
-          '\t\t<error line="11" column="19" severity="error" message="The “clear” attribute on the “br” element is obsolete. Use CSS instead." />',
+          '\t\t<error line="1" column="16" severity="error" message="Start tag seen without seeing a doctype first. Expected “&lt;!DOCTYPE html&gt;”." source="htmllint.ValidationError" />',
+          '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." source="htmllint.ValidationError" />',
+          '\t\t<error line="9" column="96" severity="error" message="An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images." source="htmllint.ValidationError" />',
+          '\t\t<error line="11" column="19" severity="error" message="The “clear” attribute on the “br” element is obsolete. Use CSS instead." source="htmllint.ValidationError" />',
           '\t</file>',
           '</checkstyle>'
         ].join('\n'),


### PR DESCRIPTION
Checkstyle parsers expect a `source` attribute for categorization.
This is useful when you aggregate Checkstyle output from several
tools. `v.Nu` doesn't provide error codes, so the best we can do is
to identify htmllint as the source.