### PR TITLE
packge.json: Use tilde for all dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "test": "grunt"
   },
   "dependencies": {
-    "async": "0.9.0",
-    "chalk": "1.0.0"
+    "async": "~0.9.0",
+    "chalk": "~1.0.0"
   },
   "devDependencies": {
-    "grunt": "0.4.5",
-    "grunt-contrib-jshint": "0.11.0",
-    "grunt-contrib-nodeunit": "0.4.1",
-    "stripcolorcodes": "^0.1.0"
+    "grunt": "~0.4.5",
+    "grunt-contrib-jshint": "~0.11.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "stripcolorcodes": "~0.1.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
There's no gain in being so strict. We could use `^` if you prefer that, but I personally prefer `~`.