### PR TITLE
Support openjdk in javadetect.js

### DIFF
--- a/lib/javadetect.js
+++ b/lib/javadetect.js
@@ -3,14 +3,14 @@
 var exec = require('child_process').exec;
 
 module.exports = function(callback) {
-	exec('java -version', function(error, stdout, stderr) {
-		if (error) {
-			return callback(error);
-		}
+  exec('java -version', function(error, stdout, stderr) {
+    if (error) {
+      return callback(error);
+    }
 
-		callback(null, {
-			version: stderr.match(/java version "(.*)"/)[1],
-			arch: stderr.match(/64-Bit/) ? 'x64' : 'ia32'
-		});
-	});
+    callback(null, {
+      version: stderr.match(/java version "(.*)"/)[1],
+      arch: stderr.match(/64-Bit/) ? 'x64' : 'ia32'
+    });
+  });
 };

--- a/lib/javadetect.js
+++ b/lib/javadetect.js
@@ -9,7 +9,7 @@ module.exports = function(callback) {
     }
 
     callback(null, {
-      version: stderr.match(/java version "(.*)"/)[1],
+      version: stderr.match(/(?:java|openjdk) version "(.*)"/)[1],
       arch: stderr.match(/64-Bit/) ? 'x64' : 'ia32'
     });
   });


### PR DESCRIPTION
Fixes #62

Also replaced tabs with spaces in `javadetect.js` to match the rest of the repo.