### PR TITLE
Test against multiple JDKs in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
-language: node_js
-node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
-before_script:
+language: java
+
+env:
+  - NODE_VERSION=0.10
+  - NODE_VERSION=0.12
+  - NODE_VERSION=iojs
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+
+before_install:
+  - nvm install "$NODE_VERSION"
+
+install:
   - npm install -g grunt-cli
+  - npm install
+
+script:
+  - npm test
+
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,12 @@ jdk:
 
 before_install:
   - nvm install "$NODE_VERSION"
+  - node --version
+  - npm --version
 
 install:
   - npm install -g grunt-cli
+  - grunt --version
   - npm install
 
 script:


### PR DESCRIPTION
Create a test matrix using multiple versions of Java and NodeJS. This will hopefully help us to catch prevent Java bugs like #62 in the future.

Changing the language to `java` is necessary here, as Travis ignores the `jdk` settings otherwise.