### PR TITLE
#65-1 Improved error message for invalid JSON from Java

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -43,7 +43,16 @@ module.exports = function(config, done) {
 
         var result = [];
         if (stderr) {
-          result = JSON.parse(stderr).messages;
+          try {
+            result = JSON.parse(stderr).messages;
+          }catch(exception){
+            // Throw a more useful error message. Leave original error intact.
+            var jsonError = new Error('Invalid JSON output from Java process ' + jar);
+            jsonError.cause = exception;
+            cb(jsonError);
+            return;
+          }
+
           result.forEach(function(message) {
             message.file = path.relative('.', message.url.replace(path.sep !== '\\' ? 'file:' : 'file:/', ''));
             if (config.absoluteFilePathsForReporter) {

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -68,5 +68,27 @@ exports.htmllint = {
         file: path.join('test', 'invalid.html')
       }
     ], 'one error from test/invalid.html, other three were ignored');
+  },
+  'java environment': {
+    setUp: function(cb) {
+      process.env.JAVA_TOOL_OPTIONS = '-Dfile.encoding=UTF8';
+      cb();
+    },
+    tearDown: function(cb) {
+      delete process.env.JAVA_TOOL_OPTIONS;
+      cb();
+    },
+    'throws useful error message if invalid JSON': function(test) {
+      test.expect(1);
+
+      var config = {
+        files: ['test/invalid.html']
+      };
+
+      htmllint(config, function(error) {
+        test.ok(error && /Invalid JSON output/.test(error.message), 'improved invalid json error');
+        test.done();
+      });
+    }
   }
 };


### PR DESCRIPTION
This fixes #65 by improving feedback when an error occurs parsing invalid JSON.

I'm not sure if [line 89](https://github.com/pedrosland/grunt-html/commit/df8cc9fd4b9dc06432bc981b83a0804c2285b1ef#diff-d9af02d9cdfaccfd805495f42cad5d83R89) is in the best way to test that but because the assertions don't halt execution I can't check for error in an assertion before and if I use an if then that throws out `test.expect(2)`.