### PR TITLE
#65-2 Handle Java tool options

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -15,6 +15,13 @@ module.exports = function(config, done) {
   // http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
   var maxBuffer = 20000 * 1024;
 
+  // new process environment
+  var environment = {};
+
+  // extra java options
+  var extraOpts = [];
+  var extraOptsStr;
+
   // replace left/right quotation marks with normal quotation marks
   function normalizeQuotationMarks(str) {
     if (str) {
@@ -23,18 +30,45 @@ module.exports = function(config, done) {
     return str;
   }
 
+  // copy environment but filter java options to pass on the command line
+  function cleanEnvironment() {
+    Object.keys(process.env)
+      .filter(function(property){
+        if(property === 'JAVA_TOOL_OPTIONS' || property === '_JAVA_OPTIONS'){
+          extraOpts.push(process.env[property]);
+          return false;
+        }
+        return true;
+      })
+      .forEach(function(property){
+        environment[property] = process.env[property];
+      });
+  }
+
   javadetect(function(err, java) {
     if (err) {
       throw err;
+    }
+
+    cleanEnvironment();
+
+    if (java.arch === 'ia32') {
+      extraOpts.push('-Xss512k');
+    }
+
+    extraOptsStr = extraOpts.join(' ');
+    if(extraOptsStr.length > 0){
+      extraOptsStr += ' ';
     }
 
     var files = config.files.map(path.normalize);
     async.mapSeries(chunkify(files, maxChars), function(chunk, cb) {
 
       // call java, increasing the default stack size for ia32 versions of the JRE and using the default setting for x64 versions
-      var cmd = 'java ' + (java.arch === 'ia32' ? '-Xss512k ' : '') + '-jar "' + jar + '" --format json ' + chunk;
+      var cmd = 'java ' + extraOptsStr + '-jar "' + jar + '" --format json ' + chunk;
       exec(cmd, {
-        'maxBuffer': maxBuffer
+        'maxBuffer': maxBuffer,
+        'env': environment
       }, function(error, stdout, stderr) {
          if (error && (error.code !== 1 || error.killed || error.signal)) {
           cb(error);

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -43,7 +43,16 @@ module.exports = function(config, done) {
 
         var result = [];
         if (stderr) {
-          result = JSON.parse(stderr).messages;
+          try {
+            result = JSON.parse(stderr).messages;
+          }catch(exception){
+            // Throw a more useful error message. Leave original error intact.
+            var jsonError = new Error('Invalid JSON output from Java process ' + jar);
+            jsonError.cause = exception;
+            cb(jsonError);
+            return;
+          }
+
           result.forEach(function(message) {
             message.file = path.relative('.', message.url.replace(path.sep !== '\\' ? 'file:' : 'file:/', ''));
             if (config.absoluteFilePathsForReporter) {

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -78,7 +78,7 @@ exports.htmllint = {
       delete process.env.JAVA_TOOL_OPTIONS;
       cb();
     },
-    'throws useful error message if invalid JSON': function(test) {
+    'nicely handles java environment variables': function(test) {
       test.expect(1);
 
       var config = {
@@ -86,7 +86,7 @@ exports.htmllint = {
       };
 
       htmllint(config, function(error) {
-        test.ok(error && /Invalid JSON output/.test(error.message), 'improved invalid json error');
+        test.ok(!error, 'no error');
         test.done();
       });
     }

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -68,5 +68,27 @@ exports.htmllint = {
         file: path.join('test', 'invalid.html')
       }
     ], 'one error from test/invalid.html, other three were ignored');
+  },
+  'java environment': {
+    setUp: function(cb) {
+      process.env.JAVA_TOOL_OPTIONS = '-Dfile.encoding=UTF8';
+      cb();
+    },
+    tearDown: function(cb) {
+      delete process.env.JAVA_TOOL_OPTIONS;
+      cb();
+    },
+    'throws useful error message if invalid JSON': function(test) {
+      test.expect(1);
+
+      var config = {
+        files: ['test/invalid.html']
+      };
+
+      htmllint(config, function(error) {
+        test.ok(error && /Invalid JSON output/.test(error.message), 'improved invalid json error');
+        test.done();
+      });
+    }
   }
 };


### PR DESCRIPTION
This also fixes #65 but goes a bit further. It includes an extra commit which prevents passing JAVA_TOOL_OPTIONS to Java's environment and adds these options on the command line instead. I'm not crazy about this workaround hence the separate PR but it should help to ensure the best out of the box experience for the user.

This builds on #66. Note that this replaces the test in #66 and df8cc9f because I couldn't find an easy way to keep that test with these changes.
