### PR TITLE
Don't generate report if there were no warnings

### DIFF
--- a/tasks/html.js
+++ b/tasks/html.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
       }
 
       // Write the output of the reporter if wanted
-      if (reporterOutput) {
+      if (reporterOutput && result.length > 0) {
         reporterOutput = grunt.template.process(reporterOutput);
         var destDir = path.dirname(reporterOutput);
         if (!grunt.file.exists(destDir)) {


### PR DESCRIPTION
Some reporters (e.g. the Violations plugin for Jenkins) crash when given
an output file with no data.