### PR TITLE
More graceful handling of JSON.parse errors

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -43,7 +43,11 @@ module.exports = function(config, done) {
 
         var result = [];
         if (stderr) {
-          result = JSON.parse(stderr).messages;
+          try {
+            result = JSON.parse(stderr).messages;
+          } catch (err) {
+            throw new Error(err + '\nInvalid input follows below:\n\n' + stderr);
+          }
           result.forEach(function(message) {
             message.file = path.relative('.', message.url.replace(path.sep !== '\\' ? 'file:' : 'file:/', ''));
             if (config.absoluteFilePathsForReporter) {


### PR DESCRIPTION
The error thrown and reported on JSON.parse problems is not very helpful -- I spent a while googling "Fatal error: Unexpected token E" before I shifted gears and dug into grunt-html's internals to find out what was going on.

While this PR doesn't fix #65 or #80, it would provide more context information that hopefully will help people running into similar errors figure out what's going on sooner.

Reproducing #65 looks like this:

```
Running "htmllint:src" (htmllint) task
Fatal error: SyntaxError: Unexpected token P
Invalid input follows below:

Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
{"messages":[]}
```