### PR TITLE
Control display of parser results based on 'type'

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,5 @@
+{
+	'preset': 'idiomatic',
+	'maximumLineLength': false,
+	'validateQuoteMarks': "'"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,52 +1,60 @@
 'use strict';
 
-module.exports = function(grunt) {
+module.exports = function( grunt ) {
 
-  grunt.initConfig({
-    htmllint: {
-      valid: 'test/valid.html',
-      invalid: 'test/*.html',
-      ignore: {
-        options: {
-          ignore: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
+    grunt.initConfig({
+        htmllint: {
+            valid: 'test/valid.html',
+            invalid: 'test/*.html',
+            ignore: {
+                options: {
+                    ignore: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
+                },
+                src: 'test/*.html'
+            },
+            invalidPhp: {
+                options: {
+                    ignore: /XML processing instructions/
+                },
+                src: 'test/*.php'
+            },
+            checkstyle: {
+                options: {
+                    reporter: 'checkstyle'
+                },
+                src: 'test/*.html'
+            },
+            json: {
+                options: {
+                    reporter: 'json'
+                },
+                src: 'test/*.html'
+            }
         },
-        src: 'test/*.html'
-      },
-      invalidPhp: {
-        options: {
-          ignore: /XML processing instructions/
+        nodeunit: {
+            files: [ 'test/**/*.js', '!test/support/**/*.js' ]
         },
-        src: 'test/*.php'
-      },
-      checkstyle: {
-        options: {
-          reporter: 'checkstyle'
+        jshint: {
+            files: [ 'Gruntfile.js', 'lib/**/*.js', 'tasks/**/*.js', 'test/**/*.js' ],
+            options: {
+                jshintrc: '.jshintrc'
+            }
         },
-        src: 'test/*.html'
-      },
-      json: {
-        options: {
-          reporter: 'json'
-        },
-        src: 'test/*.html'
-      }
-    },
-    nodeunit: {
-      files: ['test/**/*.js', '!test/support/**/*.js']
-    },
-    jshint: {
-      files: ['Gruntfile.js', 'lib/**/*.js', 'tasks/**/*.js', 'test/**/*.js'],
-      options: {
-        jshintrc: '.jshintrc'
-      }
-    }
-  });
+        jscs: {
+            files: [ 'Gruntfile.js', 'lib/**/*.js', 'tasks/**/*.js', '!test/**/*.js' ],
+            options: {
+                config: '.jscsrc',
+                verbose: true
+            }
+        }
+    });
 
-  grunt.loadTasks('tasks');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    grunt.loadTasks( 'tasks' );
+    grunt.loadNpmTasks( 'grunt-contrib-jshint' );
+    grunt.loadNpmTasks( 'grunt-contrib-nodeunit' );
+    grunt.loadNpmTasks( 'grunt-jscs' );
 
-  grunt.registerTask('test', ['jshint', 'nodeunit']);
-  grunt.registerTask('default', 'test');
+    grunt.registerTask( 'test', [ 'jscs', 'jshint', 'nodeunit' ]);
+    grunt.registerTask( 'default', 'test' );
 
 };

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ all: {
   src: "app.html"
 }
 ```
+### `errorlevels`
+
+Type: `Array`  
+Default: `'info','warning','error'`
+
+Set `errorlevels` to control which error types are returned from the validator. Ignores all other returned types.
 
 ### `force`
 

--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,16 +1,16 @@
 'use strict';
 
-module.exports = function (files, maxChars) {
+module.exports = function( files, maxChars ) {
   var filesChunk = [];
   var chunk = '';
 
-  for (var f = 0; f < files.length; f++) {
-    if (chunk.length + (files[f].length + 1) > maxChars) {
-      filesChunk.push(chunk);
+  for ( var f = 0; f < files.length; f++ ) {
+    if ( chunk.length + ( files[ f ].length + 1 ) > maxChars ) {
+      filesChunk.push( chunk );
       chunk = '';
     }
-    chunk += '"' + files[f] + '" ';
+    chunk += '"' + files[ f ] + '" ';
   }
-  filesChunk.push(chunk);
+  filesChunk.push( chunk );
   return filesChunk;
 };

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -84,7 +84,9 @@ module.exports = function(config, done) {
       for (var r = 0; r < results.length; r++) {
         result = result.concat(results[r]);
       }
-      done(null, result);
+      done(null, result.filter(function (item) {
+        return config.errorlevels.indexOf(item.type) !== -1;
+      }));
     });
   });
 };

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -1,92 +1,92 @@
 'use strict';
 
-module.exports = function(config, done) {
-  var path = require('path');
-  var exec = require('child_process').exec;
-  var chunkify = require('./chunkify');
-  var async = require('async');
-  var javadetect = require('./javadetect');
-  var jar = path.join(__dirname, '/../vnu.jar');
+module.exports = function( config, done ) {
+  var path = require( 'path' );
+  var exec = require( 'child_process' ).exec;
+  var chunkify = require( './chunkify' );
+  var async = require( 'async' );
+  var javadetect = require( './javadetect' );
+  var jar = path.join( __dirname, '/../vnu.jar' );
 
   var maxChars = 5000;
 
   // increase child process buffer to accommodate large amounts of
-  // validation output. (default is a paltry 200k.)
+  // validation output. ( default is a paltry 200k. )
   // http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
   var maxBuffer = 20000 * 1024;
 
   // replace left/right quotation marks with normal quotation marks
-  function normalizeQuotationMarks(str) {
-    if (str) {
-      str = str.replace(/[\u201c\u201d]/g, '"');
+  function normalizeQuotationMarks( str ) {
+    if ( str ) {
+      str = str.replace( /[\u201c\u201d]/g, '"' );
     }
     return str;
   }
 
-  if (!config.files.length) {
-    return done(null, []);
+  if ( !config.files.length ) {
+    return done( null, []);
   }
 
-  javadetect(function(err, java) {
-    if (err) {
+  javadetect(function( err, java ) {
+    if ( err ) {
       throw err;
     }
 
-    var files = config.files.map(path.normalize);
-    async.mapSeries(chunkify(files, maxChars), function(chunk, cb) {
+    var files = config.files.map( path.normalize );
+    async.mapSeries( chunkify( files, maxChars ), function( chunk, cb ) {
 
       // call java, increasing the default stack size for ia32 versions of the JRE and using the default setting for x64 versions
-      var cmd = 'java ' + (java.arch === 'ia32' ? '-Xss512k ' : '') + '-jar "' + jar + '" --format json ' + chunk;
-      exec(cmd, {
+      var cmd = 'java ' + ( java.arch === 'ia32' ? '-Xss512k ' : '' ) + '-jar "' + jar + '" --format json ' + chunk;
+      exec( cmd, {
         'maxBuffer': maxBuffer
-      }, function(error, stdout, stderr) {
-        if (error && (error.code !== 1 || error.killed || error.signal)) {
-          cb(error);
+      }, function( error, stdout, stderr ) {
+        if ( error && ( error.code !== 1 || error.killed || error.signal ) ) {
+          cb( error );
           return;
         }
 
         var result = [];
-        if (stderr) {
+        if ( stderr ) {
           try {
-            result = JSON.parse(stderr).messages;
-          } catch (err) {
-            throw new Error(err + '\nInvalid input follows below:\n\n' + stderr);
+            result = JSON.parse( stderr ).messages;
+          } catch ( err ) {
+            throw new Error( err + '\nInvalid input follows below:\n\n' + stderr );
           }
-          result.forEach(function(message) {
-            message.file = path.relative('.', message.url.replace(path.sep !== '\\' ? 'file:' : 'file:/', ''));
-            if (config.absoluteFilePathsForReporter) {
-              message.file = path.resolve(message.file);
+          result.forEach(function( message ) {
+            message.file = path.relative( '.', message.url.replace( path.sep !== '\\' ? 'file:' : 'file:/', '' ) );
+            if ( config.absoluteFilePathsForReporter ) {
+              message.file = path.resolve( message.file );
             }
           });
-          if (config.ignore) {
-            var ignore = config.ignore instanceof Array ? config.ignore : [config.ignore];
-            result = result.filter(function(message) {
+          if ( config.ignore ) {
+            var ignore = config.ignore instanceof Array ? config.ignore : [ config.ignore ];
+            result = result.filter(function( message ) {
               // iterate over the ignore rules and test the message agains each rule.
-              // A match should return false, which causes every() to return false and the message to be filtered out.
-              return ignore.every(function (currentValue) {
-                if (currentValue instanceof RegExp) {
-                  return !currentValue.test(message.message);
+              // A match should return false, which causes every(  ) to return false and the message to be filtered out.
+              return ignore.every(function( currentValue ) {
+                if ( currentValue instanceof RegExp ) {
+                  return !currentValue.test( message.message );
                 }
-                return normalizeQuotationMarks(currentValue) !== normalizeQuotationMarks(message.message);
+                return normalizeQuotationMarks( currentValue ) !== normalizeQuotationMarks( message.message );
               });
             });
           }
         }
-        cb(null, result);
+        cb( null, result );
       });
-    }, function (error, results) {
-      if (error) {
-        done(error);
+    }, function( error, results ) {
+      if ( error ) {
+        done( error );
         return;
       }
 
       var result = [];
-      for (var r = 0; r < results.length; r++) {
-        result = result.concat(results[r]);
+      for ( var r = 0; r < results.length; r++ ) {
+        result = result.concat( results[ r ] );
       }
-      done(null, result.filter(function (item) {
-        return config.errorlevels.indexOf(item.type) !== -1;
-      }));
+      done( null, result.filter(function( item ) {
+        return config.errorlevels.indexOf( item.type ) !== -1;
+      }) );
     });
   });
 };

--- a/lib/javadetect.js
+++ b/lib/javadetect.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var exec = require('child_process').exec;
+var exec = require( 'child_process' ).exec;
 
-module.exports = function(callback) {
-  exec('java -version', function(error, stdout, stderr) {
-    if (error) {
-      return callback(error);
+module.exports = function( callback ) {
+  exec( 'java -version', function( error, stdout, stderr ) {
+    if ( error ) {
+      return callback( error );
     }
 
-    callback(null, {
-      version: stderr.match(/(?:java|openjdk) version "(.*)"/)[1],
-      arch: stderr.match(/64-Bit/) ? 'x64' : 'ia32'
+    callback( null, {
+      version: stderr.match( /(?:java|openjdk) version "(.*)"/ )[ 1 ],
+      arch: stderr.match( /64-Bit/ ) ? 'x64' : 'ia32'
     });
   });
 };

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,36 +1,36 @@
 'use strict';
 
-var path = require('path');
-var chalk = require('chalk');
+var path = require( 'path' );
+var chalk = require( 'chalk' );
 
 // Default Grunt reporter
-var defaultReporter = function (result) {
-  var out = result.map(function(message) {
-    var output = chalk.cyan(message.file) + ' ';
-    output += chalk.red('[') + chalk.yellow('L' + message.lastLine) +
-      chalk.red(':') + chalk.yellow('C' + message.lastColumn) + chalk.red('] ');
+var defaultReporter = function( result ) {
+  var out = result.map(function( message ) {
+    var output = chalk.cyan( message.file ) + ' ';
+    output += chalk.red( '[' ) + chalk.yellow( 'L' + message.lastLine ) +
+      chalk.red( ':' ) + chalk.yellow( 'C' + message.lastColumn ) + chalk.red( '] ' );
     output += message.message;
     return output;
   });
-  return out.join('\n');
+  return out.join( '\n' );
 },
 
-// Select a reporter (if not using the default Grunt reporter)
-selectReporter = function (options) {
-  if (options.reporter === 'checkstyle') {
+// Select a reporter ( if not using the default Grunt reporter )
+selectReporter = function( options ) {
+  if ( options.reporter === 'checkstyle' ) {
     // Checkstyle XML reporter
     options.reporter = '../lib/reporters/checkstyle.js';
-  } else if (options.reporter === 'json') {
+  } else if ( options.reporter === 'json' ) {
     // JSON reporter
     options.reporter = '../lib/reporters/json.js';
-  } else if (options.reporter !== null && options.reporter !== undefined) {
+  } else if ( options.reporter !== null && options.reporter !== undefined ) {
     // Custom reporter
-    options.reporter = path.resolve(process.cwd(), options.reporter);
+    options.reporter = path.resolve( process.cwd(  ), options.reporter );
   }
 
   var reporter;
-  if (options.reporter) {
-    reporter = require(options.reporter);
+  if ( options.reporter ) {
+    reporter = require( options.reporter );
   } else {
     reporter = defaultReporter;
   }

--- a/lib/reporters/checkstyle.js
+++ b/lib/reporters/checkstyle.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-module.exports = function(results) {
-  var path = require('path'),
+module.exports = function( results ) {
+  var path = require( 'path' ),
     files = {},
     out = [],
     pairs = {
@@ -20,55 +20,55 @@ module.exports = function(results) {
       '>': '&gt;'
     };
 
-  function encode(s) {
-    for (var r in pairs) {
-      if (typeof s !== 'undefined') {
-        s = s.replace(new RegExp(r, 'g'), pairs[r]);
+  function encode( s ) {
+    for ( var r in pairs ) {
+      if ( typeof s !== 'undefined' ) {
+        s = s.replace( new RegExp( r, 'g' ), pairs[ r ] );
       }
     }
     return s || '';
   }
 
-  results.forEach(function(result) {
+  results.forEach(function( result ) {
     // Register the file
-    result.file = path.normalize(result.file);
-    if (!files[result.file]) {
-      files[result.file] = [];
+    result.file = path.normalize( result.file );
+    if ( !files[ result.file ] ) {
+      files[ result.file ] = [];
     }
 
     // Add the error
-    files[result.file].push({
+    files[ result.file ].push({
       severity: result.type,
       line: result.lastLine,
       column: result.lastColumn,
       message: result.message,
-      source: 'htmllint.Validation' + (result.type === 'error' ? 'Error' : 'Warning')
+      source: 'htmllint.Validation' + ( result.type === 'error' ? 'Error' : 'Warning' )
     });
   });
 
 
-  out.push('<?xml version="1.0" encoding="utf-8"?><checkstyle>');
+  out.push( '<?xml version="1.0" encoding="utf-8"?><checkstyle>' );
 
-  for (var fileName in files) {
-    if (files.hasOwnProperty(fileName)) {
-      out.push('\t<file name="' + fileName + '">');
-      for (var i = 0; i < files[fileName].length; i++) {
-        var issue = files[fileName][i];
+  for ( var fileName in files ) {
+    if ( files.hasOwnProperty( fileName ) ) {
+      out.push( '\t<file name="' + fileName + '">' );
+      for ( var i = 0; i < files[ fileName ].length; i++ ) {
+        var issue = files[ fileName ][ i ];
         out.push(
           '\t\t<error ' +
             'line="' + issue.line + '" ' +
             'column="' + issue.column + '" ' +
             'severity="' + issue.severity + '" ' +
-            'message="' + encode(issue.message) + '" ' +
+            'message="' + encode( issue.message ) + '" ' +
             'source="' + issue.source + '" ' +
             '/>'
-        );
+         );
       }
-      out.push('\t</file>');
+      out.push( '\t</file>' );
     }
   }
 
-  out.push('</checkstyle>');
+  out.push( '</checkstyle>' );
 
-  return out.join('\n');
+  return out.join( '\n' );
 };

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -5,10 +5,10 @@
 
 'use strict';
 
-module.exports = function(results) {
-  results.forEach(function(result) {
+module.exports = function( results ) {
+  results.forEach(function( result ) {
     // result already has 'file' property, 'url' is redundant
     delete result.url;
   });
-  return JSON.stringify(results);
+  return JSON.stringify( results );
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-nodeunit": "0.4.1",
+    "grunt-jscs": "^2.5.0",
     "stripcolorcodes": "0.1.0"
   },
   "peerDependencies": {

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -8,71 +8,71 @@
 
 'use strict';
 
-var path = require('path');
-var htmllint = require('../lib/htmllint');
-var reporters = require('../lib/reporters');
+var path = require( 'path' );
+var htmllint = require( '../lib/htmllint' );
+var reporters = require( '../lib/reporters' );
 
-module.exports = function(grunt) {
+module.exports = function( grunt ) {
 
-  grunt.registerMultiTask('htmllint', 'Validate html files', function() {
+  grunt.registerMultiTask( 'htmllint', 'Validate html files', function() {
     var done = this.async(),
-      files = grunt.file.expand(this.filesSrc),
+      files = grunt.file.expand( this.filesSrc ),
       options = this.options({
         files: files,
         force: false,
         absoluteFilePathsForReporter: false,
-        errorlevels: ['info','warning','error']
+        errorlevels: [ 'info', 'warning', 'error' ]
       }),
       force = options.force,
       reporterOutput = options.reporterOutput,
       reporter;
 
-    htmllint(options, function(error, result) {
+    htmllint( options, function( error, result ) {
       var passed = true,
         output,
         uniqueFiles;
 
       try {
-        reporter = reporters.selectReporter(options);
-      } catch (err) {
-        grunt.fatal(err);
+        reporter = reporters.selectReporter( options );
+      } catch ( err ) {
+        grunt.fatal( err );
       }
 
-      if (error) {
+      if ( error ) {
         passed = force;
-        grunt.log.error(error);
-      } else if (!result.length) {
-        grunt.log.ok(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' lint free.');
+        grunt.log.error( error );
+      } else if ( !result.length ) {
+        grunt.log.ok( files.length + ' ' + grunt.util.pluralize( files.length, 'file/files' ) + ' lint free.' );
       } else {
         passed = force;
-        output = reporter(result);
-        if (!reporterOutput) {
-          grunt.log.writeln(output);
+        output = reporter( result );
+        if ( !reporterOutput ) {
+          grunt.log.writeln( output );
         }
         uniqueFiles = result
-          .map(function(elem) {
+          .map(function( elem ) {
             return elem.file;
           })
-          .filter(function(file, index, resultFiles) {
-            return resultFiles.indexOf(file) === index;
+          .filter(function( file, index, resultFiles ) {
+            return resultFiles.indexOf( file ) === index;
           });
-        grunt.log.error(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' checked, ' +
-                        result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
-                        uniqueFiles.length + ' ' + grunt.util.pluralize(uniqueFiles.length, 'file/files'));
+        grunt.log.error( files.length + ' ' + grunt.util.pluralize( files.length, 'file/files' ) + ' checked, ' +
+                        result.length + ' ' + grunt.util.pluralize( result.length, 'error/errors' ) + ' in ' +
+                        uniqueFiles.length + ' ' + grunt.util.pluralize( uniqueFiles.length, 'file/files' ) );
       }
 
       // Write the output of the reporter if wanted
-      if (reporterOutput && result.length > 0) {
-        reporterOutput = grunt.template.process(reporterOutput);
-        var destDir = path.dirname(reporterOutput);
-        if (!grunt.file.exists(destDir)) {
-          grunt.file.mkdir(destDir);
+      if ( reporterOutput && result.length > 0 ) {
+        reporterOutput = grunt.template.process( reporterOutput );
+        var destDir = path.dirname( reporterOutput );
+        if ( !grunt.file.exists( destDir ) ) {
+          grunt.file.mkdir( destDir );
         }
-        grunt.file.write(reporterOutput, output);
-        grunt.log.ok('Report "' + reporterOutput + '" created.');
+        grunt.file.write( reporterOutput, output );
+        grunt.log.ok( 'Report "' + reporterOutput + '" created.' );
       }
 
-      done(passed);
+      done( passed );
     });
   });
 

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
       options = this.options({
         files: files,
         force: false,
-        absoluteFilePathsForReporter: false
+        absoluteFilePathsForReporter: false,
+        errorlevels: ['info','warning','error']
       }),
       force = options.force,
       reporterOutput = options.reporterOutput,

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -32,7 +32,8 @@ exports.htmllint = {
     'with relative paths': function(test) {
       var expected = expectedResults.invalid;
       run(test, {
-        files: ['test/valid.html', 'test/invalid.html']
+        files: ['test/valid.html', 'test/invalid.html'],
+        errorlevels: ['info','warning','error']
       }, expected, 'four errors from test/invalid.html');
     },
     'with absolute paths': function(test) {
@@ -47,13 +48,15 @@ exports.htmllint = {
       });
       run(test, {
         files: ['test/valid.html', 'test/invalid.html'],
-        absoluteFilePathsForReporter: true
+        absoluteFilePathsForReporter: true,
+        errorlevels: ['info','warning','error']
       }, expected, 'four errors from test/invalid.html');
     }
   },
   'empty': function(test) {
     run(test, {
-      files: []
+      files: [],
+	  errorlevels: ['info','warning','error']
     }, [], '0 errors from 0 files');
   },
   'ignore': function(test) {
@@ -63,7 +66,8 @@ exports.htmllint = {
         'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
         /attribute “[a-z]+” not allowed/i
       ],
-      files: ['test/valid.html', 'test/invalid.html']
+      files: ['test/valid.html', 'test/invalid.html'],
+      errorlevels: ['info','warning','error']
     }, [
       {
         lastLine: 9,


### PR DESCRIPTION
Create an 'errorlevels' option to control which error types are returned
from the validator. Defaults to 'info','warning','error' and ignores all
unlisted returned types.