### PR TITLE
Add ignoreWarnings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ all: {
 }
 ```
 
+### `ignoreWarnings`
+
+Type: `Boolean`
+Default: `false`
+
+Set `ignoreWarnings` to `true` to ignore all warning level messages
+
 ### `force`
 
 Type: `Boolean`  

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -61,6 +61,11 @@ module.exports = function(config, done) {
           if (config.ignore) {
             var ignore = config.ignore instanceof Array ? config.ignore : [config.ignore];
             result = result.filter(function(message) {
+              // filter out warnings - will short circuit ignore
+              if(config.ignoreWarnings && message.subType === 'warning'){
+                return false;
+              }
+
               // iterate over the ignore rules and test the message agains each rule.
               // A match should return false, which causes every() to return false and the message to be filtered out.
               return ignore.every(function (currentValue) {

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -9,7 +9,14 @@ var defaultReporter = function (result) {
     var output = chalk.cyan(message.file) + ' ';
     output += chalk.red('[') + chalk.yellow('L' + message.lastLine) +
       chalk.red(':') + chalk.yellow('C' + message.lastColumn) + chalk.red('] ');
-    output += message.message;
+    
+    if (message.type === 'error' ){
+      output += chalk.red('ERR: ' + message.message);
+    }
+    else {
+      output += chalk.yellow('WARN: ' + message.message); 
+    }
+    
     return output;
   });
   return out.join('\n');

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -71,10 +71,15 @@ module.exports = function(grunt) {
             return resultFiles.indexOf(file) === index;
           });
 
+        var warningMessage = '';
+        if (!ignoreWarnings) {
+          warningMessage = ' and ' + numWarnings + ' ' + grunt.util.pluralize(numWarnings, 'warning/warnings');
+        }
+
         grunt.log.error(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' checked, ' +
-                        (result.length - numWarnings) + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' and ' +
-                        numWarnings + ' ' + grunt.util.pluralize(numWarnings, 'warning/warnings') + ' in ' +
-                        uniqueFiles.length + ' ' + grunt.util.pluralize(uniqueFiles.length, 'file/files'));
+                      (result.length - numWarnings) + ' ' + grunt.util.pluralize(result.length, 'error/errors') + 
+                      warningMessage + ' in ' +
+                      uniqueFiles.length + ' ' + grunt.util.pluralize(uniqueFiles.length, 'file/files'));
       }
 
       // Write the output of the reporter if wanted
@@ -91,5 +96,4 @@ module.exports = function(grunt) {
       done(passed);
     });
   });
-
 };

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -47,13 +47,6 @@ module.exports = function(grunt) {
       } else {
         passed = force;
 
-        if(ignoreWarnings){
-          var tempResult = result.filter(function(message){
-            return message.type === 'error';
-          });
-          result = tempResult;
-        }
-
         var numWarnings = 0;
         result.forEach(function(message){
           numWarnings += (message.subType === 'warning') ? 1 : 0;

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -20,10 +20,12 @@ module.exports = function(grunt) {
       options = this.options({
         files: files,
         force: false,
-        absoluteFilePathsForReporter: false
+        absoluteFilePathsForReporter: false,
+        ignoreWarnings: false
       }),
       force = options.force,
       reporterOutput = options.reporterOutput,
+      ignoreWarnings = options.ignoreWarnings,
       reporter;
 
     htmllint(options, function(error, result) {
@@ -44,6 +46,19 @@ module.exports = function(grunt) {
         grunt.log.ok(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' lint free.');
       } else {
         passed = force;
+
+        if(ignoreWarnings){
+          var tempResult = result.filter(function(message){
+            return message.type === 'error';
+          });
+          result = tempResult;
+        }
+
+        var numWarnings = 0;
+        result.forEach(function(message){
+          numWarnings += (message.subType === 'warning') ? 1 : 0;
+        });
+
         output = reporter(result);
         if (!reporterOutput) {
           grunt.log.writeln(output);
@@ -55,8 +70,10 @@ module.exports = function(grunt) {
           .filter(function(file, index, resultFiles) {
             return resultFiles.indexOf(file) === index;
           });
+
         grunt.log.error(files.length + ' ' + grunt.util.pluralize(files.length, 'file/files') + ' checked, ' +
-                        result.length + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' in ' +
+                        (result.length - numWarnings) + ' ' + grunt.util.pluralize(result.length, 'error/errors') + ' and ' +
+                        numWarnings + ' ' + grunt.util.pluralize(numWarnings, 'warning/warnings') + ' in ' +
                         uniqueFiles.length + ' ' + grunt.util.pluralize(uniqueFiles.length, 'file/files'));
       }
 

--- a/test/checkstyle_test.js
+++ b/test/checkstyle_test.js
@@ -23,6 +23,7 @@ exports.checkstyle = {
           '\t\t<error line="9" column="96" severity="error" message="Attribute “unknownattr” not allowed on element “img” at this point." source="htmllint.ValidationError" />',
           '\t\t<error line="9" column="96" severity="error" message="An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images." source="htmllint.ValidationError" />',
           '\t\t<error line="11" column="19" severity="error" message="The “clear” attribute on the “br” element is obsolete. Use CSS instead." source="htmllint.ValidationError" />',
+          '\t\t<error line="13" column="37" severity="info" message="Article lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all articles." source="htmllint.ValidationWarning" />',
           '\t</file>',
           '</checkstyle>'
         ].join('\n'),

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -71,7 +71,14 @@ exports.htmllint = {
         type: 'error',
         message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
         file: path.join('test', 'invalid.html')
+      },
+      { 
+        file: 'test/invalid.html',
+        type: 'info',
+        message: 'Article lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all articles.',
+        lastLine: 13,
+        lastColumn: 37 
       }
-    ], 'one error from test/invalid.html, other three were ignored');
+    ], 'one error and one warning from test/invalid.html, other three were ignored');
   }
 };

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -80,5 +80,24 @@ exports.htmllint = {
         file: path.join('test', 'invalid.html')
       }
     ], 'one error and one warning from test/invalid.html, other three were ignored');
+  },
+  'ignoreWarnings': function(test) {
+    run(test, {
+      ignore: [
+        'The "clear" attribute on the "br" element is obsolete. Use CSS instead.',
+        'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+        /attribute “[a-z]+” not allowed/i
+      ],
+      ignoreWarnings : true,
+      files: ['test/valid.html', 'test/invalid.html']
+    }, [
+      {
+        lastLine: 9,
+        lastColumn: 96,
+        type: 'error',
+        message: 'An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+        file: path.join('test', 'invalid.html')
+      }
+    ], 'one error and one warning from test/invalid.html, other three were ignored');
   }
 };

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -73,11 +73,11 @@ exports.htmllint = {
         file: path.join('test', 'invalid.html')
       },
       { 
-        file: 'test/invalid.html',
+        lastLine: 13,
+        lastColumn: 37,
         type: 'info',
         message: 'Article lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all articles.',
-        lastLine: 13,
-        lastColumn: 37 
+        file: path.join('test', 'invalid.html')
       }
     ], 'one error and one warning from test/invalid.html, other three were ignored');
   }

--- a/test/invalid.html
+++ b/test/invalid.html
@@ -10,5 +10,8 @@
 
 <br clear="both" />
 
+<article data-grid="container-fixed"></article>
+
+
 </body>
 </html>

--- a/test/reporters_test.js
+++ b/test/reporters_test.js
@@ -20,10 +20,11 @@ exports.reporters = {
         result = expectedResults.invalid,
         reporter = reporters.defaultReporter,
         expected = [
-          invalidHtml + ' [L1:C16] Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
-          invalidHtml + ' [L9:C96] Attribute “unknownattr” not allowed on element “img” at this point.',
-          invalidHtml + ' [L9:C96] An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
-          invalidHtml + ' [L11:C19] The “clear” attribute on the “br” element is obsolete. Use CSS instead.'
+          invalidHtml + ' [L1:C16] ERR: Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.',
+          invalidHtml + ' [L9:C96] ERR: Attribute “unknownattr” not allowed on element “img” at this point.',
+          invalidHtml + ' [L9:C96] ERR: An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.',
+          invalidHtml + ' [L11:C19] ERR: The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
+          invalidHtml + ' [L13:C37] WARN: Article lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all articles.'
         ].join('\n'),
         actual = stripColorCodes(reporter(result));
       test.equal(actual, expected, 'Should report errors as a String');

--- a/test/support/expected_results.js
+++ b/test/support/expected_results.js
@@ -32,6 +32,13 @@ module.exports = {
       type: 'error',
       message: 'The “clear” attribute on the “br” element is obsolete. Use CSS instead.',
       file: invalidHtml
+    },
+    { 
+      file: 'test/invalid.html',
+      type: 'info',
+      message: 'Article lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all articles.',
+      lastLine: 13,
+      lastColumn: 37 
     }
   ]
 };


### PR DESCRIPTION
This simply adds an option to ignore warnings - if set to true, the warning-level errors are removed from the results. This works for all report types. 

**Other changes:**
- Styled the default reporter output with "ERR: " and "WARN: ", and colored the messages to help differentiate warnings from errors
- Added a unit test to cover the `ignoreWarnings` option