### PR TITLE
Use «vnu-jar» package instead

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -6,7 +6,7 @@ module.exports = function( config, done ) {
   var chunkify = require( './chunkify' );
   var async = require( 'async' );
   var javadetect = require( './javadetect' );
-  var jar = path.join( __dirname, '/../vnu.jar' );
+  var jar = require( 'vnu-jar' );
 
   var maxChars = 5000;
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "1.5.2",
     "chalk": "1.1.3",
-    "vnu-jar": "latest"
+    "vnu-jar": "16.6.29"
   },
   "devDependencies": {
     "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "async": "1.5.2",
-    "chalk": "1.1.3"
+    "chalk": "1.1.3",
+    "vnu-jar": "latest"
   },
   "devDependencies": {
     "grunt": "1.0.1",
@@ -38,7 +39,6 @@
   "files": [
     "lib",
     "tasks",
-    "LICENSE-MIT",
-    "vnu.jar"
+    "LICENSE-MIT"
   ]
 }


### PR DESCRIPTION
No longer need to keep the `vnu.jar` file in the repository. Use [vnu-jar](https://www.npmjs.com/package/vnu-jar) package instead. You never have to worry about the fresh version of `vnu.jar`.