### PR TITLE
Add ability to invoke vnu.jar as http client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ grunt.initConfig({
 
 For fast validation, keep that in a single group, as the validator initialization takes a few seconds.
 
-When combined with a watching task (such as [grunt-contrib-watch][watch]), even faster validation can be achieved by starting the validator in client mode and connecting to an already-running instance of the validator in server mode.
-This removes the time required by repeated initializations.
-See the `server` option below.
+When combined with a watching task (such as [grunt-contrib-watch][watch]), even faster validation can be achieved by starting the validator in client mode and connecting to an already-running instance of the validator in server mode. This removes the time required by repeated initializations. See the `server` option below.
 
 ## Options
 
@@ -80,7 +78,8 @@ To start the validator in server mode, use `java -cp "path/to/vnu.jar" nu.valida
 ```js
 all: {
   options: {
-    server: {} // connect to a validator instance running in server mode on localhost:8888
+    // connect to a validator instance running in server mode on localhost:8888
+    server: {}
   },
   src: "app.html"
 }
@@ -92,7 +91,8 @@ The `server` object also accepts the `host` and `port` keys, specifying the loca
 all: {
   options: {
     server: {
-      host: '192.168.0.5', // your team's local dev tool machine, for example
+      // your team's local dev tool machine, for example
+      host: '192.168.0.5',
       port: 8877
     }
   },
@@ -100,21 +100,36 @@ all: {
 }
 ```
 
-In the following example, a watching task (such as [grunt-contrib-watch][watch]) will complete significantly faster when executing `htmllint:client` as opposed to `htmllint:normal`.
+The following configuration in Gruntfile.js uses [grunt-vnuserver][vnuserver] to start the validator in server mode and sets up a watch task to run `htmllint` every time the source file changes.
+By starting the validator in server mode once using the `vnuserver` task, validations by `htmllint` can be performed much faster by simply connecting to this already-running server.
 
 ```js
-htmllint: {
-  normal: {
-    src: "app.html"
-  },
-  client: {
-    options: {
-      server: {}
-    },
-    src: "app.html"
-  }
-}
+module.exports = function (grunt) {
+    grunt.initConfig({
+        vnuserver: {
+        },
+        htmllint: {
+            all: {
+                options: {
+                    server: {}
+                },
+                src: "app.html"
+            }
+        },
+        watch: {
+            all: {
+                tasks: ['htmllint'],
+                files: "app.html"
+            }
+        },
+    });
 
+    grunt.loadNpmTasks('grunt-vnuserver');
+    grunt.loadNpmTasks('grunt-html');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+
+    grunt.registerTask('default', ['vnuserver', 'watch']);
+};
 ```
 
 ### `errorlevels`
@@ -167,3 +182,4 @@ Licensed under the MIT license.
 [getting_started]: http://gruntjs.com/getting-started
 [vnujar]: https://validator.github.io/validator/
 [watch]: https://github.com/gruntjs/grunt-contrib-watch
+[vnuserver]: https://www.npmjs.com/package/grunt-vnuserver

--- a/README.md
+++ b/README.md
@@ -105,30 +105,30 @@ By starting the validator in server mode once using the `vnuserver` task, valida
 
 ```js
 module.exports = function (grunt) {
-    grunt.initConfig({
-        vnuserver: {
+  grunt.initConfig({
+    vnuserver: {
+    },
+    htmllint: {
+      all: {
+        options: {
+          server: {}
         },
-        htmllint: {
-            all: {
-                options: {
-                    server: {}
-                },
-                src: "app.html"
-            }
-        },
-        watch: {
-            all: {
-                tasks: ['htmllint'],
-                files: "app.html"
-            }
-        },
-    });
+        src: "app.html"
+      }
+    },
+    watch: {
+      all: {
+        tasks: ['htmllint'],
+        files: "app.html"
+      }
+    }
+  });
 
-    grunt.loadNpmTasks('grunt-vnuserver');
-    grunt.loadNpmTasks('grunt-html');
-    grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-vnuserver');
+  grunt.loadNpmTasks('grunt-html');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
-    grunt.registerTask('default', ['vnuserver', 'watch']);
+  grunt.registerTask('default', ['vnuserver', 'watch']);
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ grunt.initConfig({
 
 For fast validation, keep that in a single group, as the validator initialization takes a few seconds.
 
+When combined with a watching task (such as [grunt-contrib-watch][watch]), even faster validation can be achieved by starting the validator in client mode and connecting to an already-running instance of the validator in server mode.
+This removes the time required by repeated initializations.
+See the `server` option below.
+
 ## Options
 
 ### `ignore`
@@ -61,6 +65,56 @@ all: {
   },
   src: "app.html"
 }
+```
+
+### `server`
+
+* Type: `Object`, or a falsy value
+* Default: `false`
+
+When `server` is set to a falsy value, the validator is invoked using `java -jar`, which can be considered normal operation.
+
+Set `server` to an object to start the validator in client mode and connect to an already-running instance of the validator in server mode.
+To start the validator in server mode, use `java -cp "path/to/vnu.jar" nu.validator.servlet.Main <port>`.
+
+```js
+all: {
+  options: {
+    server: {} // connect to a validator instance running in server mode on localhost:8888
+  },
+  src: "app.html"
+}
+```
+
+The `server` object also accepts the `host` and `port` keys, specifying the location of the server.
+
+```js
+all: {
+  options: {
+    server: {
+      host: '192.168.0.5', // your team's local dev tool machine, for example
+      port: 8877
+    }
+  },
+  src: "app.html"
+}
+```
+
+In the following example, a watching task (such as [grunt-contrib-watch][watch]) will complete significantly faster when executing `htmllint:client` as opposed to `htmllint:normal`.
+
+```js
+htmllint: {
+  normal: {
+    src: "app.html"
+  },
+  client: {
+    options: {
+      server: {}
+    },
+    src: "app.html"
+  }
+}
+
 ```
 
 ### `errorlevels`
@@ -112,3 +166,4 @@ Licensed under the MIT license.
 [grunt]: http://gruntjs.com/
 [getting_started]: http://gruntjs.com/getting-started
 [vnujar]: https://validator.github.io/validator/
+[watch]: https://github.com/gruntjs/grunt-contrib-watch

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -23,12 +23,18 @@ module.exports = function( config, done ) {
     return str;
   }
 
-  // parse and, if needed, normalize error messages from HttpClient to vnu.jar format
+  // parse and, if needed, normalize error messages from HttpClient to java -jar format
+  // java -jar: one object containing messages for all files
+  //   { messages: [{ message, type, url, ... }, ...] }
+  // HttpClient: one object per file, separated by a newline, each object containing messages for only that file
+  //   { messages: [{ message, type, ...}, ...], url }\n{ ... }
   function parseErrorMessages( errors ) {
     var parsed = JSON.parse( config.server ? '[' + errors.trim().replace( /\n/g, ',' ) + ']' : errors );
     var messages = parsed.messages;
     if ( config.server ) {
-      messages = [].concat.apply([], parsed.map(function( file ) {
+      // extract "messages" property from each object and set the url of each message
+      // this results in an array of arrays instead of array of objects, which is then flattened by concatenation
+      messages = Array.prototype.concat.apply([], parsed.map(function( file ) {
         return file.messages.map(function( message ) {
           message.url = file.url;
           return message;
@@ -36,6 +42,25 @@ module.exports = function( config, done ) {
       }) );
     }
     return messages;
+  }
+
+  // determine proper jarfile command and arguments
+  function cmd( java, chunk ) {
+    var args = '';
+    if ( config.server ) {
+      if ( config.server.host ) {
+        args += ' -Dnu.validator.client.host=' + config.server.host;
+      }
+      if ( config.server.port ) {
+        args += ' -Dnu.validator.client.port=' + config.server.port;
+      }
+      args += ' -Dnu.validator.client.out=json nu.validator.client.HttpClient';
+    } else {
+      args += ' --format json';
+    }
+    var invoke = ( config.server ? '-cp' : '-jar' ) + ' "' + jar + '"' + args;
+    // command to call java, increasing the default stack size for ia32 versions of the JRE and using the default setting for x64 versions
+    return 'java ' + ( java.arch === 'ia32' ? '-Xss512k ' : '' ) + invoke + ' ' + chunk;
   }
 
   if ( !config.files.length ) {
@@ -54,14 +79,7 @@ module.exports = function( config, done ) {
     var files = config.files.map( path.normalize );
     async.mapSeries( chunkify( files, maxChars ), function( chunk, cb ) {
 
-      // determine proper jarfile invokation and arguments.
-      var args = config.server ? ( config.server.host ? ' -Dnu.validator.client.host=' + config.server.host : '' ) +
-                                 ( config.server.port ? ' -Dnu.validator.client.port=' + config.server.port : '' ) +
-                                 ' -Dnu.validator.client.out=json nu.validator.client.HttpClient' : ' --format json';
-      var invoke = ( config.server ? '-cp' : '-jar' ) + ' "' + jar + '"' + args;
-      // call java, increasing the default stack size for ia32 versions of the JRE and using the default setting for x64 versions
-      var cmd = 'java ' + ( java.arch === 'ia32' ? '-Xss512k ' : '' ) + invoke + ' ' + chunk;
-      exec( cmd, {
+      exec( cmd( java, chunk ), {
         'maxBuffer': maxBuffer
       }, function( error, stdout, stderr ) {
         if ( error && ( error.code !== 1 || error.killed || error.signal ) ) {

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -23,6 +23,21 @@ module.exports = function( config, done ) {
     return str;
   }
 
+  // parse and, if needed, normalize error messages from HttpClient to vnu.jar format
+  function parseErrorMessages( errors ) {
+    var parsed = JSON.parse( config.server ? '[' + errors.trim().replace( /\n/g, ',' ) + ']' : errors );
+    var messages = parsed.messages;
+    if ( config.server ) {
+      messages = [].concat.apply([], parsed.map(function( file ) {
+        return file.messages.map(function( message ) {
+          message.url = file.url;
+          return message;
+        });
+      }) );
+    }
+    return messages;
+  }
+
   if ( !config.files.length ) {
     return done( null, []);
   }
@@ -39,8 +54,13 @@ module.exports = function( config, done ) {
     var files = config.files.map( path.normalize );
     async.mapSeries( chunkify( files, maxChars ), function( chunk, cb ) {
 
+      // determine proper jarfile invokation and arguments.
+      var args = config.server ? ( config.server.host ? ' -Dnu.validator.client.host=' + config.server.host : '' ) +
+                                 ( config.server.port ? ' -Dnu.validator.client.port=' + config.server.port : '' ) +
+                                 ' -Dnu.validator.client.out=json nu.validator.client.HttpClient' : ' --format json';
+      var invoke = ( config.server ? '-cp' : '-jar' ) + ' "' + jar + '"' + args;
       // call java, increasing the default stack size for ia32 versions of the JRE and using the default setting for x64 versions
-      var cmd = 'java ' + ( java.arch === 'ia32' ? '-Xss512k ' : '' ) + '-jar "' + jar + '" --format json ' + chunk;
+      var cmd = 'java ' + ( java.arch === 'ia32' ? '-Xss512k ' : '' ) + invoke + ' ' + chunk;
       exec( cmd, {
         'maxBuffer': maxBuffer
       }, function( error, stdout, stderr ) {
@@ -49,10 +69,11 @@ module.exports = function( config, done ) {
           return;
         }
 
+        stderr = config.server ? stdout : stderr;
         var result = [];
         if ( stderr ) {
           try {
-            result = JSON.parse( stderr ).messages;
+            result = parseErrorMessages( stderr );
           } catch ( err ) {
             throw new Error( err + '\nInvalid input follows below:\n\n' + stderr );
           }


### PR DESCRIPTION
The long(ish) startup time of vnu.jar becomes somewhat annoying when the rest of the project builds in a couple of seconds. I've noticed that performance is radically increased when vnu.jar has been started in servlet mode and the build process sends the files to the already-running servlet to validate. When combined with a watching task (such as grunt-watch) this becomes a very viable solution, by starting the servlet once and then simply querying it on each rebuild.

For 92 html files in a sample project, htmllint takes 3.9s in its current state. When a vnu.jar servlet is running and htmllint connects to the server, the same files take 2s to validate. This is a full 1.9s overhead, simply due to startup time.

Adding a ``server`` field in the task options enables this functionality, with ``server: {}`` connecting to localhost:8888 (vnu.jar defaults), and ``server: {host: 'hostname', port: port}`` connecting to hostname:port.

I was tempted to simply allow injecting command line arguments to the java process directly, but this way is more generic, abstracting from the underlying validator allowing it to change without breaking anything (so long as it also supports connecting to a server).