### PR TITLE
Compensate for JAVA_TOOL_OPTIONS environment variable

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -15,6 +15,13 @@ module.exports = function( config, done ) {
   // http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
   var maxBuffer = 20000 * 1024;
 
+  // new process environment
+  var environment = {};
+
+  // extra java options
+  var extraOpts = [];
+  var extraOptsStr;
+
   // replace left/right quotation marks with normal quotation marks
   function normalizeQuotationMarks( str ) {
     if ( str ) {
@@ -27,6 +34,21 @@ module.exports = function( config, done ) {
     return done( null, []);
   }
 
+  // copy environment but filter java options to pass on the command line
+  function cleanEnvironment() {
+    Object.keys( process.env )
+      .filter(function( property ) {
+        if ( property === 'JAVA_TOOL_OPTIONS' || property === '_JAVA_OPTIONS' ) {
+          extraOpts.push( process.env[ property ] );
+          return false;
+        }
+        return true;
+      })
+      .forEach(function( property ) {
+        environment[ property ] = process.env[ property ];
+      });
+  }
+
   javadetect(function( err, java ) {
     if ( err ) {
       throw err;
@@ -36,13 +58,25 @@ module.exports = function( config, done ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. v1.8 is required!' );
     }
 
+    cleanEnvironment();
+
+    if ( java.arch === 'ia32' ) {
+      extraOpts.push( '-Xss512k' );
+    }
+
+    extraOptsStr = extraOpts.join( ' ' );
+    if ( extraOptsStr.length > 0 ) {
+      extraOptsStr += ' ';
+    }
+
     var files = config.files.map( path.normalize );
     async.mapSeries( chunkify( files, maxChars ), function( chunk, cb ) {
 
       // call java, increasing the default stack size for ia32 versions of the JRE and using the default setting for x64 versions
-      var cmd = 'java ' + ( java.arch === 'ia32' ? '-Xss512k ' : '' ) + '-jar "' + jar + '" --format json ' + chunk;
+      var cmd = 'java ' + extraOptsStr + '-jar "' + jar + '" --format json ' + chunk;
       exec( cmd, {
-        'maxBuffer': maxBuffer
+        'maxBuffer': maxBuffer,
+        'env': environment
       }, function( error, stdout, stderr ) {
         if ( error && ( error.code !== 1 || error.killed || error.signal ) ) {
           cb( error );
@@ -53,9 +87,14 @@ module.exports = function( config, done ) {
         if ( stderr ) {
           try {
             result = JSON.parse( stderr ).messages;
-          } catch ( err ) {
-            throw new Error( err + '\nInvalid input follows below:\n\n' + stderr );
+          } catch ( exception ) {
+            // Throw a more useful error message. Leave original error intact.
+            var jsonError = new Error( 'Invalid JSON output from Java process ' + jar );
+            jsonError.cause = exception;
+            cb( jsonError );
+            return;
           }
+
           result.forEach(function( message ) {
             if ( message.url ) {
               message.file = path.relative( '.', message.url.replace( path.sep !== '\\' ? 'file:' : 'file:/', '' ) );

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -112,5 +112,27 @@ exports.htmllint = {
         file: path.join( 'test', 'invalid.html' )
       }
     ], 'one error from test/invalid.html, other three were ignored' );
+  },
+  'java environment': {
+    setUp: function( cb ) {
+      process.env.JAVA_TOOL_OPTIONS = '-Dfile.encoding=UTF8';
+      cb();
+    },
+    tearDown: function( cb ) {
+      delete process.env.JAVA_TOOL_OPTIONS;
+      cb();
+    },
+    'nicely handles java environment variables': function( test ) {
+      test.expect( 1 );
+
+      var config = {
+        files: [ 'test/invalid.html' ]
+      };
+
+      htmllint( config, function( error ) {
+        test.ok( !error, 'no error' );
+        test.done();
+      });
+    }
   }
 };


### PR DESCRIPTION
If this environment variable is set then we won't get valid JSON from the validator - it'll be prefixed by a message from Java.
We filter the environment for the Java process to exclude this and pass these arguments on the command line instead.

Also, improve error message for invalid JSON from Java.