### PR TITLE
Java 9 compatibility

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -72,7 +72,7 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    if ( java.version[ 0 ] !== '1' || ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
+    if ( (java.version[ 0 ] !== '1' || java.version[ 0 ] !== '9') || ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. v1.8 is required!' );
     }
 

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -72,7 +72,7 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    if ( (java.version[ 0 ] !== '1' || java.version[ 0 ] !== '9') || ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
+    if ( ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. v1.8 is required!' );
     }
 


### PR DESCRIPTION
Since Java 9 JDKs show versions numers like "9...." instead of "1.9....", we have to adjust jdk version detection.

For now, this version ist java 9 compatible but in the future we have to accept even more naming schemes (like "18.04", "18.10"...)

