### PR TITLE
Added support for Java 9 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,9 @@ Set `absoluteFilePathsForReporter` to `true` to use absolute file paths in gener
 
 Set `noLangDetect` to `true` to [skip the checking of the language of the page](https://github.com/validator/validator#--no-langdetect).
 
-## Travis CI potential pitfalls
+## Potential pitfalls
 
-Since vnu.jar requires Java 8 environment, you might have trouble setting Travis CI to work with grunt-html.
-In that case see [this patch](https://github.com/jquery/jquery-ui/commit/ff3769272bb5530b224297fa5d2add1865acbb7f)
-and the [Travis CI doc page](https://docs.travis-ci.com/user/trusty-ci-environment/).
+* vnu.jar requires Java 8 environment or up.
 
 ## License
 

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -75,8 +75,8 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    if ( java.version[ 0 ] !== '1' || ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
-      throw new Error( '\nUnsupported Java version used: ' + java.version + '. v1.8 is required!' );
+    if ( ( java.version[ 0 ] !== '1' && java.version[ 0 ] < '8' ) || ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
+      throw new Error( '\nUnsupported Java version used: ' + java.version + '. Java 8 environment or up is required!' );
     }
 
     var files = config.files.map( path.normalize );

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -75,7 +75,7 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    var javaVersion = java.version.split('.').map( Number );
+    var javaVersion = java.version.split( '.' ).map( Number );
     if ( ( javaVersion[ 0 ] !== 1 && javaVersion[ 0 ] < 8 ) || ( javaVersion[ 0 ] === 1 && javaVersion[ 1 ] < 8 ) ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. Java 8 environment or up is required!' );
     }

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -75,7 +75,7 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    var javaVersion = java.version.split('.').map(Number);
+    var javaVersion = java.version.split('.').map( Number );
     if ( ( javaVersion[ 0 ] !== 1 && javaVersion[ 0 ] < 8 ) || ( javaVersion[ 0 ] === 1 && javaVersion[ 1 ] < 8 ) ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. Java 8 environment or up is required!' );
     }

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -75,7 +75,8 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    if ( ( java.version[ 0 ] !== '1' && java.version[ 0 ] < '8' ) || ( java.version[ 0 ] === '1' && java.version[ 2 ] < '8' ) ) {
+    var java_version = java.version.split('.').map(Number);
+    if ( ( java_version[ 0 ] !== 1 && java_version[ 0 ] < 8 ) || ( java_version[ 0 ] === 1 && java_version[ 1 ] < 8 ) ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. Java 8 environment or up is required!' );
     }
 

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -75,8 +75,8 @@ module.exports = function( config, done ) {
       throw err;
     }
 
-    var java_version = java.version.split('.').map(Number);
-    if ( ( java_version[ 0 ] !== 1 && java_version[ 0 ] < 8 ) || ( java_version[ 0 ] === 1 && java_version[ 1 ] < 8 ) ) {
+    var javaVersion = java.version.split('.').map(Number);
+    if ( ( javaVersion[ 0 ] !== 1 && javaVersion[ 0 ] < 8 ) || ( javaVersion[ 0 ] === 1 && javaVersion[ 1 ] < 8 ) ) {
       throw new Error( '\nUnsupported Java version used: ' + java.version + '. Java 8 environment or up is required!' );
     }
 


### PR DESCRIPTION
Support for java > 8 is broken.

The code assumes that `java -version` outputs **1**.x:
```
    if ( java.version[ 0 ] !== '1' || ( java.version[ 0 ] === '1' && java.version[ 2 ] <= '8' ) ) {
      throw new Error( '\nUnsupported Java version used: ' + java.version + '. v1.8 is required!' );
    }
```

Java 9 `java -version`:
```
java version "9.0.4"
Java(TM) SE Runtime Environment (build 9.0.4+11)
Java HotSpot(TM) 64-Bit Server VM (build 9.0.4+11, mixed mode)
```

Java 10 `java -version`:
```
java version "10.0.1" 2018-04-17
Java(TM) SE Runtime Environment 18.3 (build 10.0.1+10)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.1+10, mixed mode)
```

Fixed the check and updated the README to reflect support for Java 8+.